### PR TITLE
feat: 로그아웃 API 

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/api/response/SuccessCode.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/response/SuccessCode.java
@@ -8,6 +8,7 @@ public enum SuccessCode {
     OK(HttpStatus.OK, "SUCCESS", "요청이 성공적으로 처리되었습니다."),
     LOGIN_URL_ISSUED(HttpStatus.OK, "SUCCESS", "로그인 URL 발급에 성공했습니다."),
     LOGIN_SUCCESS(HttpStatus.OK, "SUCCESS", "로그인에 성공했습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "SUCCESS", "로그아웃에 성공했습니다."),
     CREATED(HttpStatus.CREATED, "CREATED", "생성에 성공했습니다."),
     NO_CONTENT(HttpStatus.NO_CONTENT, "NO_CONTENT", "성공적으로 처리되었으며, 반환할 데이터가 없습니다.");
 

--- a/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.sipomeokjo.commitme.security.AuthLoginAuthenticationFilter;
 import com.sipomeokjo.commitme.security.AuthLoginAuthenticationProvider;
 import com.sipomeokjo.commitme.security.AuthLoginFailureHandler;
 import com.sipomeokjo.commitme.security.AuthLoginSuccessHandler;
+import com.sipomeokjo.commitme.security.AuthLogoutSuccessHandler;
 import com.sipomeokjo.commitme.security.CustomAccessDeniedHandler;
 import com.sipomeokjo.commitme.security.CustomAuthenticationEntryPoint;
 import com.sipomeokjo.commitme.security.JwtFilter;
@@ -34,6 +35,7 @@ public class SecurityConfig {
 	private final AuthLoginAuthenticationProvider authLoginAuthenticationProvider;
 	private final AuthLoginSuccessHandler authLoginSuccessHandler;
 	private final AuthLoginFailureHandler authLoginFailureHandler;
+	private final AuthLogoutSuccessHandler authLogoutSuccessHandler;
 	
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -50,6 +52,7 @@ public class SecurityConfig {
 					-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers(HttpMethod.GET, "/auth/token").permitAll()
+						.requestMatchers(HttpMethod.POST, "/auth/logout").permitAll()
 						.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 						.requestMatchers(
 								"/auth/github/loginUrl",
@@ -60,6 +63,11 @@ public class SecurityConfig {
 								"/v3/api-docs/**"
 						).permitAll()
 						.anyRequest().authenticated()
+				)
+				.logout(logout -> logout
+						.logoutUrl("/auth/logout")
+						.logoutSuccessHandler(authLogoutSuccessHandler)
+						.permitAll()
 				)
 				.exceptionHandling(exception ->exception
 						.authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
 		
 		ResponseCookie cookie = ResponseCookie.from("state", state)
 				.httpOnly(true)
-				.secure(false)
+				.secure(true)
 				.sameSite("Lax")
 				.path("/auth/github")
 				.maxAge(Duration.ofMinutes(10))

--- a/src/main/java/com/sipomeokjo/commitme/security/AuthLoginAuthenticationFilter.java
+++ b/src/main/java/com/sipomeokjo/commitme/security/AuthLoginAuthenticationFilter.java
@@ -9,12 +9,17 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
-import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 
 public class AuthLoginAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
 	public AuthLoginAuthenticationFilter() {
-		super(new RegexRequestMatcher("^/auth/github$", HttpMethod.GET.name()));
+		super(request -> {
+			String uri = request.getRequestURI();
+			if (!HttpMethod.GET.matches(request.getMethod())) {
+				return false;
+			}
+			return "/auth/github".equals(uri);
+		});
 	}
 
 	@Override

--- a/src/main/java/com/sipomeokjo/commitme/security/AuthLogoutSuccessHandler.java
+++ b/src/main/java/com/sipomeokjo/commitme/security/AuthLogoutSuccessHandler.java
@@ -1,0 +1,60 @@
+package com.sipomeokjo.commitme.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sipomeokjo.commitme.api.response.ApiResponse;
+import com.sipomeokjo.commitme.api.response.SuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthLogoutSuccessHandler implements LogoutSuccessHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void onLogoutSuccess(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			Authentication authentication
+	) throws IOException {
+		ResponseCookie expireAccess = ResponseCookie.from("access_token", "")
+				.httpOnly(true)
+				.secure(true)
+				.sameSite("Lax")
+				.path("/")
+				.maxAge(Duration.ZERO)
+				.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, expireAccess.toString());
+
+		ResponseCookie expireRefresh = ResponseCookie.from("refresh_token", "")
+				.httpOnly(true)
+				.secure(true)
+				.sameSite("Lax")
+				.path("/auth/token")
+				.maxAge(Duration.ZERO)
+				.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, expireRefresh.toString());
+
+		ApiResponse<Void> body = new ApiResponse<>(
+				SuccessCode.LOGOUT_SUCCESS.getCode(),
+				SuccessCode.LOGOUT_SUCCESS.getMessage(),
+				null
+		);
+		response.setStatus(SuccessCode.LOGOUT_SUCCESS.getHttpStatus().value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		objectMapper.writeValue(response.getOutputStream(), body);
+		log.info("[Auth][Logout] 로그아웃 처리 완료");
+	}
+}


### PR DESCRIPTION
### Description

로그아웃 API를 구현합니다.

### Changes Made

1. LogoutFilter를 통해 로그아웃 처리
2. 로그아웃 시 access_token, refresh_token cookie 만료 후 응답 반환

### Testing

<img width="148" height="69" alt="Screenshot 2026-01-22 at 15 09 41" src="https://github.com/user-attachments/assets/464257ce-7f21-4dd8-b9fd-c361004c4596" />

1. 로그인을 완료하여 토큰을 발급받은 상태
2. /auth/logout 실행

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.