### PR TITLE
feat: 유저 설정 조회, 수정 API 구현

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/controller/UserSettingController.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/controller/UserSettingController.java
@@ -1,0 +1,40 @@
+package com.sipomeokjo.commitme.domain.userSetting.controller;
+
+import com.sipomeokjo.commitme.api.response.APIResponse;
+import com.sipomeokjo.commitme.api.response.SuccessCode;
+import com.sipomeokjo.commitme.domain.userSetting.dto.UserSettingsResponse;
+import com.sipomeokjo.commitme.domain.userSetting.dto.UserSettingsUpdateRequest;
+import com.sipomeokjo.commitme.domain.userSetting.service.UserSettingCommandService;
+import com.sipomeokjo.commitme.domain.userSetting.service.UserSettingQueryService;
+import com.sipomeokjo.commitme.security.CurrentUserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user/settings")
+@RequiredArgsConstructor
+public class UserSettingController {
+
+    private final UserSettingQueryService userSettingQueryService;
+    private final UserSettingCommandService userSettingCommandService;
+
+    @GetMapping
+    public ResponseEntity<APIResponse<UserSettingsResponse>> getSettings(
+            @CurrentUserId Long userId) {
+        return APIResponse.onSuccess(SuccessCode.USER_SETTINGS_FETCHED,
+				userSettingQueryService.getSettings(userId));
+    }
+
+    @PatchMapping
+    public ResponseEntity<APIResponse<UserSettingsResponse>> updateSettings(
+            @CurrentUserId Long userId,
+            @RequestBody UserSettingsUpdateRequest request) {
+        return APIResponse.onSuccess(SuccessCode.USER_SETTINGS_UPDATED,
+				userSettingCommandService.updateSettings(userId, request));
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/dto/UserSettingsResponse.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/dto/UserSettingsResponse.java
@@ -1,0 +1,8 @@
+package com.sipomeokjo.commitme.domain.userSetting.dto;
+
+public record UserSettingsResponse(
+        Long userId,
+        boolean notificationEnabled,
+        boolean interviewResumeDefaultsEnabled
+) {
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/dto/UserSettingsUpdateRequest.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/dto/UserSettingsUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.sipomeokjo.commitme.domain.userSetting.dto;
+
+public record UserSettingsUpdateRequest(
+        Boolean notificationEnabled,
+        Boolean interviewResumeDefaultsEnabled
+) {
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/entity/UserSetting.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/entity/UserSetting.java
@@ -1,0 +1,63 @@
+package com.sipomeokjo.commitme.domain.userSetting.entity;
+
+import com.sipomeokjo.commitme.domain.user.entity.User;
+import com.sipomeokjo.commitme.global.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_settings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSetting extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "notification_enabled", nullable = false)
+    private boolean notificationEnabled;
+
+    @Column(name = "interview_resume_defaults_enabled", nullable = false)
+    private boolean interviewResumeDefaultsEnabled;
+
+    @Builder
+    public UserSetting(Long id, User user, boolean notificationEnabled, boolean interviewResumeDefaultsEnabled) {
+        this.id = id;
+        this.user = user;
+        this.notificationEnabled = notificationEnabled;
+        this.interviewResumeDefaultsEnabled = interviewResumeDefaultsEnabled;
+    }
+
+    public static UserSetting defaultSetting(User user) {
+        return UserSetting.builder()
+                .user(user)
+                .notificationEnabled(true)
+                .interviewResumeDefaultsEnabled(false)
+                .build();
+    }
+
+    public void update(Boolean notificationEnabled, Boolean interviewResumeDefaultsEnabled) {
+        if (notificationEnabled != null) {
+            this.notificationEnabled = notificationEnabled;
+        }
+        if (interviewResumeDefaultsEnabled != null) {
+            this.interviewResumeDefaultsEnabled = interviewResumeDefaultsEnabled;
+        }
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/mapper/UserSettingMapper.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/mapper/UserSettingMapper.java
@@ -1,0 +1,20 @@
+package com.sipomeokjo.commitme.domain.userSetting.mapper;
+
+import com.sipomeokjo.commitme.domain.userSetting.dto.UserSettingsResponse;
+import com.sipomeokjo.commitme.domain.userSetting.entity.UserSetting;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserSettingMapper {
+
+    public UserSettingsResponse toResponse(UserSetting setting) {
+        if (setting == null) {
+            return null;
+        }
+        return new UserSettingsResponse(
+                setting.getId(),
+                setting.isNotificationEnabled(),
+                setting.isInterviewResumeDefaultsEnabled()
+        );
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/repository/UserSettingRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/repository/UserSettingRepository.java
@@ -1,0 +1,10 @@
+package com.sipomeokjo.commitme.domain.userSetting.repository;
+
+import com.sipomeokjo.commitme.domain.userSetting.entity.UserSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
+
+    Optional<UserSetting> findByUserId(Long userId);
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/service/UserSettingCommandService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/service/UserSettingCommandService.java
@@ -1,0 +1,29 @@
+package com.sipomeokjo.commitme.domain.userSetting.service;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.userSetting.dto.UserSettingsResponse;
+import com.sipomeokjo.commitme.domain.userSetting.dto.UserSettingsUpdateRequest;
+import com.sipomeokjo.commitme.domain.userSetting.entity.UserSetting;
+import com.sipomeokjo.commitme.domain.userSetting.mapper.UserSettingMapper;
+import com.sipomeokjo.commitme.domain.userSetting.repository.UserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserSettingCommandService {
+
+    private final UserSettingRepository userSettingRepository;
+    private final UserSettingMapper userSettingMapper;
+
+    public UserSettingsResponse updateSettings(Long userId, UserSettingsUpdateRequest request) {
+        UserSetting setting = userSettingRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_SETTINGS_NOT_FOUND));
+
+        setting.update(request.notificationEnabled(), request.interviewResumeDefaultsEnabled());
+        return userSettingMapper.toResponse(setting);
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/userSetting/service/UserSettingQueryService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/userSetting/service/UserSettingQueryService.java
@@ -1,0 +1,26 @@
+package com.sipomeokjo.commitme.domain.userSetting.service;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.userSetting.dto.UserSettingsResponse;
+import com.sipomeokjo.commitme.domain.userSetting.entity.UserSetting;
+import com.sipomeokjo.commitme.domain.userSetting.mapper.UserSettingMapper;
+import com.sipomeokjo.commitme.domain.userSetting.repository.UserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserSettingQueryService {
+
+    private final UserSettingRepository userSettingRepository;
+    private final UserSettingMapper userSettingMapper;
+
+    public UserSettingsResponse getSettings(Long userId) {
+        UserSetting setting = userSettingRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_SETTINGS_NOT_FOUND));
+        return userSettingMapper.toResponse(setting);
+    }
+}


### PR DESCRIPTION
### Description

유저의 설정을 조회하고 수정하는 API를 구현합니다.

### Related Issues

- Resolves #12 

### Changes Made

1. 유저의 개인 설정 정보 조회 API
2. 유저의 개인 설정 정보 수정 API

### Testing
<img width="400" alt="Screenshot 2026-01-25 at 14 29 12" src="https://github.com/user-attachments/assets/7d2c29ba-abaf-4b50-8405-4326efa27f50" />

<img width="400" alt="Screenshot 2026-01-25 at 14 29 20" src="https://github.com/user-attachments/assets/f9cbf91b-044b-44d1-8600-b41e27e96f37" />


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.