### PR TITLE
feat: 채팅방 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/api/response/SuccessCode.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/response/SuccessCode.java
@@ -10,9 +10,12 @@ public enum SuccessCode implements ResponseCode {
     LOGIN_SUCCESS(HttpStatus.OK, "SUCCESS", "로그인에 성공했습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK, "SUCCESS", "로그아웃에 성공했습니다."),
     POSITION_LIST_FETCHED(HttpStatus.OK, "SUCCESS", "포지션 목록 조회에 성공했습니다."),
-    USER_PROFILE_FETCHED(HttpStatus.OK, "SUCCESS", "내 정보를 조회했습니다."),
+    USER_PROFILE_FETCHED(HttpStatus.OK, "SUCCESS", "내 정보 조회에 성공했습니다."),
     USER_PROFILE_UPDATED(HttpStatus.OK, "SUCCESS", "회원 정보가 수정되었습니다."),
     ONBOARDING_COMPLETED(HttpStatus.OK, "SUCCESS", "회원가입이 완료되었습니다."),
+    USER_SETTINGS_FETCHED(HttpStatus.OK, "SUCCESS", "사용자 설정 조회에 성공했습니다."),
+    USER_SETTINGS_UPDATED(HttpStatus.OK, "SUCCESS", "사용자 설정 수정에 성공했습니다."),
+	CHATROOM_FETCHED(HttpStatus.OK, "SUCCESS", "채팅방 목록 조회에 성공했습니다."),
     CREATED(HttpStatus.CREATED, "CREATED", "생성에 성공했습니다."),
     NO_CONTENT(HttpStatus.NO_CONTENT, "NO_CONTENT", "성공적으로 처리되었으며, 반환할 데이터가 없습니다.");
 

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/controller/ChatController.java
@@ -1,0 +1,29 @@
+package com.sipomeokjo.commitme.domain.chat.controller;
+
+import com.sipomeokjo.commitme.api.response.APIResponse;
+import com.sipomeokjo.commitme.api.response.SuccessCode;
+import com.sipomeokjo.commitme.domain.chat.dto.ChatroomResponse;
+import com.sipomeokjo.commitme.domain.chat.service.ChatroomQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/chats")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatroomQueryService chatroomQueryService;
+	
+	@GetMapping
+	public ResponseEntity<APIResponse<List<ChatroomResponse>>> getChatRoom() {
+		return APIResponse.onSuccess(SuccessCode.CHATROOM_FETCHED,
+				chatroomQueryService.getAllChatroom());
+	}
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/dto/ChatroomResponse.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/dto/ChatroomResponse.java
@@ -1,0 +1,10 @@
+package com.sipomeokjo.commitme.domain.chat.dto;
+
+import java.time.Instant;
+
+public record ChatroomResponse(
+		Long id,
+		String name,
+		String lastMessage,
+		Instant lastUpdatedAt
+) { }

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/ChatAttachment.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/ChatAttachment.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Builder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -47,4 +48,14 @@ public class ChatAttachment {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    @Builder
+    public ChatAttachment(Long id, ChatMessage message, ChatAttachmentType fileType, String fileUrl, Integer orderNo, Instant createdAt) {
+        this.id = id;
+        this.message = message;
+        this.fileType = fileType;
+        this.fileUrl = fileUrl;
+        this.orderNo = orderNo;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/ChatMessage.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Builder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -33,7 +34,7 @@ public class ChatMessage {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "chatroom_id", nullable = false)
-    private ChatRoom chatroom;
+    private Chatroom chatroom;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "sender_id", nullable = false)
@@ -62,4 +63,16 @@ public class ChatMessage {
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
+    @Builder
+    public ChatMessage(Long id, Chatroom chatroom, User sender, User mentionUser, ChatMessageStatus status, ChatMessageRole role, ChatMessageType messageType, String message, Instant createdAt) {
+        this.id = id;
+        this.chatroom = chatroom;
+        this.sender = sender;
+        this.mentionUser = mentionUser;
+        this.status = status;
+        this.role = role;
+        this.messageType = messageType;
+        this.message = message;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/ChatUserNumber.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/ChatUserNumber.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Builder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -31,7 +32,7 @@ public class ChatUserNumber {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "chatroom_id", nullable = false)
-    private ChatRoom chatroom;
+    private Chatroom chatroom;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
@@ -43,4 +44,13 @@ public class ChatUserNumber {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
+
+    @Builder
+    public ChatUserNumber(Long id, Chatroom chatroom, User user, Integer number, Instant createdAt) {
+        this.id = id;
+        this.chatroom = chatroom;
+        this.user = user;
+        this.number = number;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/Chatroom.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/entity/Chatroom.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "position_chat_chatroom")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatRoom extends BaseEntity {
+public class Chatroom extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/repository/ChatroomRepository.java
@@ -1,0 +1,36 @@
+package com.sipomeokjo.commitme.domain.chat.repository;
+
+import com.sipomeokjo.commitme.domain.chat.dto.ChatroomResponse;
+import com.sipomeokjo.commitme.domain.chat.entity.Chatroom;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+
+    @Query("""
+        select new com.sipomeokjo.commitme.domain.chat.dto.ChatroomResponse(
+            chatRoom.id,
+            chatRoom.position.name,
+            chatMessage.message,
+            chatMessage.createdAt
+        )
+        from Chatroom chatRoom
+        left join ChatMessage chatMessage
+            on chatMessage.chatroom = chatRoom
+            and chatMessage.id = (
+                select max(message.id)
+                from ChatMessage message
+                where message.chatroom = chatRoom
+                    and message.createdAt = (
+                        select max(latestMessage.createdAt)
+                        from ChatMessage latestMessage
+                        where latestMessage.chatroom = chatRoom
+                    )
+            )
+        order by chatMessage.createdAt desc, chatMessage.id desc
+        """)
+    List<ChatroomResponse> findAllChatroom();
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/chat/service/ChatroomQueryService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/chat/service/ChatroomQueryService.java
@@ -1,0 +1,20 @@
+package com.sipomeokjo.commitme.domain.chat.service;
+
+import com.sipomeokjo.commitme.domain.chat.dto.ChatroomResponse;
+import com.sipomeokjo.commitme.domain.chat.repository.ChatroomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatroomQueryService {
+
+    private final ChatroomRepository chatroomRepository;
+
+    public List<ChatroomResponse> getAllChatroom() {
+        return chatroomRepository.findAllChatroom();
+    }
+}


### PR DESCRIPTION
### Description

채팅방 목록을 조회하는 API를 구현합니다.

### Related Issues

- Resolves #16 

### Changes Made

채팅방명, 마지막 전송 채팅 내용과 전송 시각을 받을 수 있는 API를 구현

### Testing

<img width="500" alt="Screenshot 2026-01-26 at 16 00 45" src="https://github.com/user-attachments/assets/f7e1300c-8fe7-41eb-8f38-9b27073d9372" />


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.