### PR TITLE
fix: 채팅 내역 조회 정렬 기준 변경

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/api/pagination/CursorRequest.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/pagination/CursorRequest.java
@@ -1,7 +1,7 @@
 package com.sipomeokjo.commitme.api.pagination;
 
 public record CursorRequest(
-		String after,
+		String next,
 		Integer size
 ) {
 	public int limit(int defaultSize) {


### PR DESCRIPTION
### Description

채팅 내역 조회 시 정렬 기준을 기획과 동일하게 변경합니다.

### Related Issues

- Resolves #28 

### Changes Made

1. 채팅 내역 조회 기준 변경
2. CursorRequest의 파라미터 명칭 변경

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.