### PR TITLE
fix: CSRF 원본 토큰 허용

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/config/LocalSecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/LocalSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.sipomeokjo.commitme.config;
 
+import com.sipomeokjo.commitme.security.csrf.CsrfTokenResponseCookieFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -8,6 +9,8 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @Profile("local")
@@ -21,9 +24,12 @@ public class LocalSecurityConfig {
                         csrf ->
                                 csrf.csrfTokenRepository(
                                                 CookieCsrfTokenRepository.withHttpOnlyFalse())
+                                        .csrfTokenRequestHandler(
+                                                new CsrfTokenRequestAttributeHandler())
                                         .ignoringRequestMatchers("/api/v1/resume/callback"))
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .httpBasic(Customizer.withDefaults())
+                .addFilterAfter(new CsrfTokenResponseCookieFilter(), CsrfFilter.class)
                 .build();
     }
 }

--- a/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sipomeokjo.commitme.config;
 
 import com.sipomeokjo.commitme.security.CookieProperties;
 import com.sipomeokjo.commitme.security.CryptoProperties;
+import com.sipomeokjo.commitme.security.csrf.CsrfTokenResponseCookieFilter;
 import com.sipomeokjo.commitme.security.jwt.JwtFilter;
 import com.sipomeokjo.commitme.security.jwt.JwtProperties;
 import com.sipomeokjo.commitme.security.oauth.AuthLoginAuthenticationFilter;
@@ -26,6 +27,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -63,6 +66,8 @@ public class SecurityConfig {
                         csrf ->
                                 csrf.csrfTokenRepository(
                                                 CookieCsrfTokenRepository.withHttpOnlyFalse())
+                                        .csrfTokenRequestHandler(
+                                                new CsrfTokenRequestAttributeHandler())
                                         .ignoringRequestMatchers("/api/v1/resume/callback"))
                 .cors(Customizer.withDefaults())
                 .sessionManagement(
@@ -102,6 +107,7 @@ public class SecurityConfig {
                                 exception
                                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                                         .accessDeniedHandler(customAccessDeniedHandler))
+                .addFilterAfter(new CsrfTokenResponseCookieFilter(), CsrfFilter.class)
                 .addFilterBefore(authLoginFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/sipomeokjo/commitme/security/csrf/CsrfTokenResponseCookieFilter.java
+++ b/src/main/java/com/sipomeokjo/commitme/security/csrf/CsrfTokenResponseCookieFilter.java
@@ -1,0 +1,26 @@
+package com.sipomeokjo.commitme.security.csrf;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class CsrfTokenResponseCookieFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        if (csrfToken == null) {
+            csrfToken = (CsrfToken) request.getAttribute("_csrf");
+        }
+        if (csrfToken != null) {
+            csrfToken.getToken();
+        }
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
### Description

CSRF 토큰을 전송하고 있음에도 불구하고 원본 

### Related Issues

- Resolves #58 

### Changes Made

0. Spring Security 6부터는 마스킹된 CSRF 토큰을 기대하나 원본 토큰을 받았기 때문에 Invalid Token으로 인한 403 에러 발생
1. 원본 Token도 허용할 수 있도록 변경

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.