### PR TITLE
ci: defend rollback by health check

### DIFF
--- a/.github/workflows/be-cd.yml
+++ b/.github/workflows/be-cd.yml
@@ -125,6 +125,8 @@ jobs:
             # 6. 서비스 시작
             echo "[5/6] 서비스 시작..."
             sudo systemctl start $SERVICE_NAME
+            
+            sleep 20
 
             # 7. Health Check
             echo "[6/6] Health Check..."


### PR DESCRIPTION
배포 직후 health check 로 인해
헬스체크 실패 후 rollback 이 발생하는 문제가 있었습니다.

배포 후 잠시 기다린 후 헬스체크 진행하는 방식으로 cd 파이프라인 수정하였습니다.