### PR TITLE
fix: 회원가입 중 S3 이미지 업로드 가능하도록 구현

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
@@ -78,6 +78,8 @@ public class SecurityConfig {
                                         .permitAll()
                                         .requestMatchers(HttpMethod.GET, "/auth/token")
                                         .permitAll()
+                                        .requestMatchers(HttpMethod.POST, "/uploads")
+                                        .hasAnyRole("PENDING", "ACTIVE")
                                         .requestMatchers(HttpMethod.POST, "/auth/logout")
                                         .permitAll()
                                         .requestMatchers(HttpMethod.OPTIONS, "/**")


### PR DESCRIPTION
### Description

S3 이미지 업로드 API 제한으로 인해 회원가입 중 이미지 업로드하지 못하는 문제 수정

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.