### PR TITLE
fix: exclude S3 upload API from CSRF protection

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/config/LocalSecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/LocalSecurityConfig.java
@@ -26,7 +26,8 @@ public class LocalSecurityConfig {
                                                 CookieCsrfTokenRepository.withHttpOnlyFalse())
                                         .csrfTokenRequestHandler(
                                                 new CsrfTokenRequestAttributeHandler())
-                                        .ignoringRequestMatchers("/api/v1/resume/callback"))
+                                        .ignoringRequestMatchers(
+                                                "/api/v1/resume/callback", "/uploads/**"))
                 .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .httpBasic(Customizer.withDefaults())
                 .addFilterAfter(new CsrfTokenResponseCookieFilter(), CsrfFilter.class)

--- a/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
                                                 CookieCsrfTokenRepository.withHttpOnlyFalse())
                                         .csrfTokenRequestHandler(
                                                 new CsrfTokenRequestAttributeHandler())
-                                        .ignoringRequestMatchers("/api/v1/resume/callback"))
+                                        .ignoringRequestMatchers(
+                                                "/api/v1/resume/callback", "/uploads/**"))
                 .cors(Customizer.withDefaults())
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
### Description

CSRF 대상에서 S3 upload API를 제외하지 않아 S3 업로드가 제대로 되지 않는 문제 해결

### Testing

iOS/Chrome/Localhost

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.