### PR TITLE
fix: csrf URL 명시적 부여를 통해 배포 서버에서의 CSRF 토큰 문제 해결

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/config/CsrfProperties.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/CsrfProperties.java
@@ -1,0 +1,6 @@
+package com.sipomeokjo.commitme.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.csrf")
+public record CsrfProperties(String cookieDomain) {}

--- a/src/main/java/com/sipomeokjo/commitme/config/LocalSecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/LocalSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.sipomeokjo.commitme.config;
 
 import com.sipomeokjo.commitme.security.csrf.CsrfTokenResponseCookieFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -14,13 +15,19 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @Profile("local")
+@RequiredArgsConstructor
 public class LocalSecurityConfig {
+
+    private final CsrfProperties csrfProperties;
 
     @Bean
     @Order(0)
     public SecurityFilterChain localPermitAllFilterChain(HttpSecurity http) throws Exception {
         CookieCsrfTokenRepository csrfTokenRepository =
                 CookieCsrfTokenRepository.withHttpOnlyFalse();
+        if (csrfProperties.cookieDomain() != null && !csrfProperties.cookieDomain().isBlank()) {
+            csrfTokenRepository.setCookieDomain(csrfProperties.cookieDomain());
+        }
         return http.securityMatcher("/**")
                 .csrf(
                         csrf ->

--- a/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
@@ -41,7 +41,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
     CookieProperties.class,
     CryptoProperties.class,
     CorsProperties.class,
-    AuthRedirectProperties.class
+    AuthRedirectProperties.class,
+    CsrfProperties.class
 })
 public class SecurityConfig {
 
@@ -52,6 +53,7 @@ public class SecurityConfig {
     private final AuthLoginSuccessHandler authLoginSuccessHandler;
     private final AuthLoginFailureHandler authLoginFailureHandler;
     private final AuthLogoutSuccessHandler authLogoutSuccessHandler;
+    private final CsrfProperties csrfProperties;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -61,6 +63,9 @@ public class SecurityConfig {
         authLoginFilter.setAuthenticationFailureHandler(authLoginFailureHandler);
         CookieCsrfTokenRepository csrfTokenRepository =
                 CookieCsrfTokenRepository.withHttpOnlyFalse();
+        if (csrfProperties.cookieDomain() != null && !csrfProperties.cookieDomain().isBlank()) {
+            csrfTokenRepository.setCookieDomain(csrfProperties.cookieDomain());
+        }
 
         http.formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
### Description

배포 서버에서 CSRF 토큰 쿠키를 제대로 받아오지 못 하는 문제를 해결하기 위해 쿠키를 받아오는 URL을 명시적으로 작성하였습니다.