### PR TITLE
refactor: Resume AI request via async event listener/publisher

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/config/AsyncConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.sipomeokjo.commitme.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/event/ResumeAiGenerateEvent.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/event/ResumeAiGenerateEvent.java
@@ -1,0 +1,6 @@
+package com.sipomeokjo.commitme.domain.resume.event;
+
+import java.util.List;
+
+public record ResumeAiGenerateEvent(
+        Long resumeVersionId, Long userId, String positionName, List<String> repoUrls) {}

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeAiRequestService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeAiRequestService.java
@@ -1,0 +1,84 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.auth.entity.AuthProvider;
+import com.sipomeokjo.commitme.domain.auth.repository.AuthRepository;
+import com.sipomeokjo.commitme.domain.resume.config.AiProperties;
+import com.sipomeokjo.commitme.domain.resume.dto.ai.AiResumeGenerateRequest;
+import com.sipomeokjo.commitme.domain.resume.dto.ai.AiResumeGenerateResponse;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersion;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import com.sipomeokjo.commitme.domain.resume.event.ResumeAiGenerateEvent;
+import com.sipomeokjo.commitme.domain.resume.repository.ResumeVersionRepository;
+import com.sipomeokjo.commitme.security.jwt.AccessTokenCipher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeAiRequestService {
+
+    private final ResumeVersionRepository resumeVersionRepository;
+    private final AuthRepository authRepository;
+    private final AccessTokenCipher accessTokenCipher;
+    private final RestClient aiClient;
+    private final AiProperties aiProperties;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleGenerate(ResumeAiGenerateEvent event) {
+        if (event == null || event.resumeVersionId() == null) {
+            return;
+        }
+
+        ResumeVersion version =
+                resumeVersionRepository.findById(event.resumeVersionId()).orElse(null);
+
+        if (version == null || version.getStatus() != ResumeVersionStatus.QUEUED) {
+            return;
+        }
+
+        String githubToken;
+        try {
+            var auth =
+                    authRepository
+                            .findByUser_IdAndProvider(event.userId(), AuthProvider.GITHUB)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED));
+            githubToken = accessTokenCipher.decrypt(auth.getAccessToken());
+        } catch (Exception e) {
+            version.failNow("AI_GENERATE_FAILED", e.getMessage());
+            return;
+        }
+
+        AiResumeGenerateRequest aiReq =
+                new AiResumeGenerateRequest(event.repoUrls(), event.positionName(), githubToken);
+
+        try {
+            String url = aiProperties.getBaseUrl() + aiProperties.getResumeGeneratePath();
+
+            AiResumeGenerateResponse aiRes =
+                    aiClient.post()
+                            .uri(url)
+                            .body(aiReq)
+                            .retrieve()
+                            .body(AiResumeGenerateResponse.class);
+
+            if (aiRes == null || aiRes.jobId() == null || aiRes.jobId().isBlank()) {
+                version.failNow("AI_RESPONSE_INVALID", "jobId is null/blank");
+                return;
+            }
+
+            version.startProcessing(aiRes.jobId());
+        } catch (Exception e) {
+            version.failNow("AI_GENERATE_FAILED", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### Description

AI 서버로의 이력서 생성 요청을 `@EventListener`와 `@Async`를 활용한 비동기로 처리하게 개선합니다.

### Related Issues

- Resolves #94 

### Changes Made

1. 이력서 생성 요청이 들어오는 경우 해당 요청 트랜잭션 커밋 완료 후 AI 서버로 이력서 생성 요청을 보내도록 구현
2. 스레드 분리를 통해 응답 시간이 AI 서버에 영향을 받지 않도록 개선

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.