### PR TITLE
refactor: 로컬 캐싱 적용

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/position/service/PositionQueryService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/position/service/PositionQueryService.java
@@ -5,6 +5,7 @@ import com.sipomeokjo.commitme.domain.position.mapper.PositionMapper;
 import com.sipomeokjo.commitme.domain.position.repository.PositionRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class PositionQueryService {
     private final PositionRepository positionRepository;
     private final PositionMapper positionMapper;
 
+	@Cacheable(cacheNames = "positions", key = "'all'")
     public List<PositionResponse> getPositions() {
         return positionRepository.findAll(Sort.by(Sort.Direction.ASC, "id")).stream()
                 .map(positionMapper::toResponse)


### PR DESCRIPTION
### Description

조회는 잦으나 변경이 거의 없는 고정 데이터인 Positions에 대해 로컬 캐싱을 적용합니다.

### Related Issues

- Resolves #108

### Changes Made

1. `@Cacheable` 어노테이션을 사용하여 Positions에 대하여 캐싱 적용
2. 변경/삭제를 진행하는 API도 없는 단순 조회용 데이터이기에 Caffeine 등의 추가 라이브러리가 불필요하다고 판단하여 Spring cache 기본 로컬 캐시 사용

### Testing

iOS/Chrome/Localhost

1. 최초 서버 실행 후 API 호출 시 SQL 쿼리 호출 확인
2. API 재호출 시 SQL 쿼리 미호출 확인

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.