### PR TITLE
fix: 이력서 수정 시 정확한 ResumeVersion 반환하도록 변경

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/ResumeVersionRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/ResumeVersionRepository.java
@@ -22,6 +22,9 @@ public interface ResumeVersionRepository extends JpaRepository<ResumeVersion, Lo
             findTopByResume_IdAndStatusAndCommittedAtIsNullAndPreviewShownAtIsNullOrderByVersionNoDesc(
                     Long resumeId, ResumeVersionStatus status);
 
+    Optional<ResumeVersion> findTopByResume_IdAndStatusOrderByVersionNoDesc(
+            Long resumeId, ResumeVersionStatus status);
+
     @Query(
             value =
                     "SELECT rv.version_no AS versionNo "

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeService.java
@@ -258,7 +258,7 @@ public class ResumeService {
 
         var latestSucceeded =
                 resumeVersionRepository
-                        .findTopByResume_IdAndStatusAndCommittedAtIsNullAndPreviewShownAtIsNullOrderByVersionNoDesc(
+                        .findTopByResume_IdAndStatusOrderByVersionNoDesc(
                                 resume.getId(), ResumeVersionStatus.SUCCEEDED)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));


### PR DESCRIPTION
### Description

이력서 수정 요청 시 특정 이력서의 버전을 찾을 수 없다는 오류가 지속적으로 노출되던 오류 해결
특정 이력서 버전 상세 조회 시 미저장 완료본 1회 노출 UX를 구현하고자 상세 조회 시점에 previewShownAt 컬럼을 채우도록 구현해두었음.
이력서 수정을 위해 특정 이력서 버전을 조회하는 메서드를 사용, 해당 이력서의 버전에 previewShownAt 컬럼이 채워짐.
1. AI 편집 완료, 버전 SUCCEEDED
2. 상세 조회 (get) 호출 시, preview 노출 처리로 previewShownAt 채워짐
3. edit 호출 시, previewShownAt IS NULL 조건이 불일치하여 조회 실패
4. `RESUME_VERSION_NOT_FOUND` 발생
5. 

### Related Issues

- Resolves #138 

### Changes Made

edit() 전용 조회 기준을 분리


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
