### PR TITLE
feat: 관측성 매트릭 확장

### DIFF
--- a/codedeploy/scripts/fetch-env-from-ssm.sh
+++ b/codedeploy/scripts/fetch-env-from-ssm.sh
@@ -62,6 +62,9 @@ spring:
     url: "${DB_URL}"
     username: "${DB_USER}"
     password: "${DB_PASS}"
+    hikari:
+      register-mbeans: true
+      pool-name: CommitmeHikariPool
   data:
     redis:
       host: "${REDIS_IP}"
@@ -91,9 +94,16 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,info,metrics,prometheus
+  metrics:
+    tags:
+      application: CommitMe
+      env: prod
         
 app:
+  observability:
+    jdbc:
+      slow-query-threshold-ms: 300
   auth:
     redirect-uri: "${APP_AUTH_REDIRECT_URI}"
   cors:

--- a/src/main/java/com/sipomeokjo/commitme/config/DevDataSourceProxyConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/DevDataSourceProxyConfig.java
@@ -1,12 +1,15 @@
 package com.sipomeokjo.commitme.config;
 
 import com.sipomeokjo.commitme.logging.DevQueryLogEntryCreator;
+import com.sipomeokjo.commitme.metrics.JdbcQueryMetricsListener;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 import net.ttddyy.dsproxy.listener.logging.SLF4JLogLevel;
 import net.ttddyy.dsproxy.listener.logging.SLF4JQueryLoggingListener;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,8 +20,22 @@ import org.springframework.context.annotation.Profile;
 public class DevDataSourceProxyConfig {
 
     @Bean
-    public BeanPostProcessor dataSourceProxyPostProcessor() {
+    public BeanPostProcessor dataSourceProxyPostProcessor(
+            ObjectProvider<MeterRegistry> meterRegistryProvider,
+            JdbcMetricsProperties jdbcMetricsProperties) {
         return new BeanPostProcessor() {
+            private JdbcQueryMetricsListener jdbcQueryMetricsListener;
+
+            private JdbcQueryMetricsListener jdbcQueryMetricsListener() {
+                if (jdbcQueryMetricsListener == null) {
+                    jdbcQueryMetricsListener =
+                            new JdbcQueryMetricsListener(
+                                    meterRegistryProvider.getObject(),
+                                    jdbcMetricsProperties.slowQueryThresholdMs());
+                }
+                return jdbcQueryMetricsListener;
+            }
+
             @Override
             public Object postProcessAfterInitialization(Object bean, String beanName) {
                 if (bean instanceof DataSource && !(bean instanceof ProxyDataSource)) {
@@ -29,8 +46,11 @@ public class DevDataSourceProxyConfig {
                     return ProxyDataSourceBuilder.create((DataSource) bean)
                             .name("CommitmeDS")
                             .countQuery()
+                            .listener(jdbcQueryMetricsListener())
                             .listener(listener)
-                            .logSlowQueryBySlf4j(1, TimeUnit.SECONDS)
+                            .logSlowQueryBySlf4j(
+                                    jdbcMetricsProperties.slowQueryThresholdMs(),
+                                    TimeUnit.MILLISECONDS)
                             .build();
                 }
                 return bean;

--- a/src/main/java/com/sipomeokjo/commitme/config/JdbcMetricsProperties.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/JdbcMetricsProperties.java
@@ -1,0 +1,13 @@
+package com.sipomeokjo.commitme.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.observability.jdbc")
+public record JdbcMetricsProperties(Long slowQueryThresholdMs) {
+
+    public JdbcMetricsProperties {
+        if (slowQueryThresholdMs == null || slowQueryThresholdMs <= 0) {
+            slowQueryThresholdMs = 300L;
+        }
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/config/ProdDataSourceProxyConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/ProdDataSourceProxyConfig.java
@@ -1,9 +1,12 @@
 package com.sipomeokjo.commitme.config;
 
+import com.sipomeokjo.commitme.metrics.JdbcQueryMetricsListener;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 import net.ttddyy.dsproxy.support.ProxyDataSource;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,14 +17,31 @@ import org.springframework.context.annotation.Profile;
 public class ProdDataSourceProxyConfig {
 
     @Bean
-    public BeanPostProcessor dataSourceProxyPostProcessor() {
+    public BeanPostProcessor dataSourceProxyPostProcessor(
+            ObjectProvider<MeterRegistry> meterRegistryProvider,
+            JdbcMetricsProperties jdbcMetricsProperties) {
         return new BeanPostProcessor() {
+            private JdbcQueryMetricsListener jdbcQueryMetricsListener;
+
+            private JdbcQueryMetricsListener jdbcQueryMetricsListener() {
+                if (jdbcQueryMetricsListener == null) {
+                    jdbcQueryMetricsListener =
+                            new JdbcQueryMetricsListener(
+                                    meterRegistryProvider.getObject(),
+                                    jdbcMetricsProperties.slowQueryThresholdMs());
+                }
+                return jdbcQueryMetricsListener;
+            }
+
             @Override
             public Object postProcessAfterInitialization(Object bean, String beanName) {
                 if (bean instanceof DataSource && !(bean instanceof ProxyDataSource)) {
                     return ProxyDataSourceBuilder.create((DataSource) bean)
                             .name("CommitmeDS")
-                            .logSlowQueryBySlf4j(1, TimeUnit.SECONDS)
+                            .listener(jdbcQueryMetricsListener())
+                            .logSlowQueryBySlf4j(
+                                    jdbcMetricsProperties.slowQueryThresholdMs(),
+                                    TimeUnit.MILLISECONDS)
                             .build();
                 }
                 return bean;

--- a/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
+++ b/src/main/java/com/sipomeokjo/commitme/config/SecurityConfig.java
@@ -115,6 +115,8 @@ public class SecurityConfig {
                                                 "/api/resume/*/callback",
                                                 "/api/ai/callback/**",
                                                 "/actuator/health",
+                                                "/actuator/prometheus", // internal scrape path
+                                                // (SG/ALB 제한 전제)
                                                 "/swagger/**",
                                                 "/swagger-ui/**",
                                                 "/swagger-ui.html",

--- a/src/main/java/com/sipomeokjo/commitme/metrics/JdbcQueryMetricsListener.java
+++ b/src/main/java/com/sipomeokjo/commitme/metrics/JdbcQueryMetricsListener.java
@@ -1,0 +1,102 @@
+package com.sipomeokjo.commitme.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+
+public class JdbcQueryMetricsListener implements QueryExecutionListener {
+
+    private static final String JDBC_QUERY_EXECUTION_TIMER = "jdbc.query.execution";
+    private static final String JDBC_QUERY_SLOW_COUNTER = "jdbc.query.slow";
+    private static final String UNKNOWN = "unknown";
+
+    private final MeterRegistry meterRegistry;
+    private final long slowQueryThresholdMs;
+
+    public JdbcQueryMetricsListener(MeterRegistry meterRegistry, long slowQueryThresholdMs) {
+        this.meterRegistry = meterRegistry;
+        this.slowQueryThresholdMs = Math.max(1L, slowQueryThresholdMs);
+    }
+
+    @Override
+    public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {}
+
+    @Override
+    public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        long elapsedTimeMs = Math.max(0L, execInfo.getElapsedTime());
+        String datasource = safeTagValue(execInfo.getDataSourceName());
+        String statementType = resolveStatementType(execInfo, queryInfoList);
+        String success = Boolean.toString(execInfo.isSuccess());
+        String batch = Boolean.toString(execInfo.isBatch());
+
+        Timer.builder(JDBC_QUERY_EXECUTION_TIMER)
+                .tag("datasource", datasource)
+                .tag("success", success)
+                .tag("statement_type", statementType)
+                .tag("batch", batch)
+                .register(meterRegistry)
+                .record(elapsedTimeMs, TimeUnit.MILLISECONDS);
+
+        if (elapsedTimeMs < slowQueryThresholdMs) {
+            return;
+        }
+
+        Counter.builder(JDBC_QUERY_SLOW_COUNTER)
+                .tag("datasource", datasource)
+                .tag("success", success)
+                .tag("statement_type", statementType)
+                .tag("batch", batch)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private String resolveStatementType(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        if (queryInfoList != null) {
+            for (QueryInfo queryInfo : queryInfoList) {
+                if (queryInfo == null) {
+                    continue;
+                }
+                String sqlVerb = extractSqlVerb(queryInfo.getQuery());
+                if (!UNKNOWN.equals(sqlVerb)) {
+                    return sqlVerb;
+                }
+            }
+        }
+
+        if (execInfo.getStatementType() == null) {
+            return UNKNOWN;
+        }
+        return execInfo.getStatementType().name().toLowerCase(Locale.ROOT);
+    }
+
+    private String extractSqlVerb(String query) {
+        if (query == null || query.isBlank()) {
+            return UNKNOWN;
+        }
+
+        String trimmedQuery = query.stripLeading();
+        int endIndex = 0;
+        while (endIndex < trimmedQuery.length()
+                && Character.isLetter(trimmedQuery.charAt(endIndex))) {
+            endIndex++;
+        }
+
+        if (endIndex == 0) {
+            return UNKNOWN;
+        }
+        return trimmedQuery.substring(0, endIndex).toLowerCase(Locale.ROOT);
+    }
+
+    private String safeTagValue(String value) {
+        if (value == null || value.isBlank()) {
+            return UNKNOWN;
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
# 적용한 관측성 매트릭 목록

- JVM 메트릭 (jvm_*)
    - jvm_threads_live_threads
    - jvm_memory_used_bytes
    - jvm_gc_pause_seconds_*
- HikariCP 메트릭 (hikaricp_*)
    - hikaricp_connections_active
    - hikaricp_connections_pending
    - hikaricp_connections_idle
    - hikaricp_connections_max
- Process/System 메트릭
    - process_*
    - system_*
- JDBC 커스텀 메트릭 (jdbc_query_*)
    - jdbc_query_execution_seconds_*
    - jdbc_query_slow_total