### PR TITLE
feat: Redis 기반 분산 SSE 라우팅 및 타겟 인스턴스 채널로만 전송 적용

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/api/sse/SseEmitterRegistry.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/SseEmitterRegistry.java
@@ -11,9 +11,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Component
 public class SseEmitterRegistry {
     private static final long DEFAULT_TIMEOUT_MS = 30 * 60 * 1000L;
-    private final Map<Long, List<SseEmitter>> emittersByKey = new ConcurrentHashMap<>();
+    private final Map<SseStreamKey, List<SseEmitter>> emittersByKey = new ConcurrentHashMap<>();
 
-    public SseEmitter register(Long key) {
+    public SseEmitter register(SseStreamKey key) {
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT_MS);
         emittersByKey.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>()).add(emitter);
 
@@ -24,11 +24,11 @@ public class SseEmitterRegistry {
         return emitter;
     }
 
-    public List<SseEmitter> getEmitters(Long key) {
+    public List<SseEmitter> getEmitters(SseStreamKey key) {
         return emittersByKey.get(key);
     }
 
-    public void forEachEmitter(BiConsumer<Long, SseEmitter> consumer) {
+    public void forEachEmitter(BiConsumer<SseStreamKey, SseEmitter> consumer) {
         emittersByKey.forEach(
                 (key, emitters) -> {
                     for (SseEmitter emitter : emitters) {
@@ -37,7 +37,7 @@ public class SseEmitterRegistry {
                 });
     }
 
-    public void remove(Long key, SseEmitter emitter) {
+    public void remove(SseStreamKey key, SseEmitter emitter) {
         List<SseEmitter> emitters = emittersByKey.get(key);
         if (emitters == null) {
             return;
@@ -48,7 +48,7 @@ public class SseEmitterRegistry {
         }
     }
 
-    public void completeWithError(Long key, SseEmitter emitter, Throwable throwable) {
+    public void completeWithError(SseStreamKey key, SseEmitter emitter, Throwable throwable) {
         try {
             emitter.completeWithError(throwable);
         } catch (Exception ignored) {
@@ -58,7 +58,7 @@ public class SseEmitterRegistry {
         }
     }
 
-    public int count(Long key) {
+    public int count(SseStreamKey key) {
         List<SseEmitter> emitters = emittersByKey.get(key);
         return emitters == null ? 0 : emitters.size();
     }

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/SseHeartbeatScheduler.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/SseHeartbeatScheduler.java
@@ -1,5 +1,11 @@
 package com.sipomeokjo.commitme.api.sse;
 
+import com.sipomeokjo.commitme.api.sse.distributed.SseInstanceIdProvider;
+import com.sipomeokjo.commitme.api.sse.distributed.SseRouteKey;
+import com.sipomeokjo.commitme.api.sse.distributed.SseRouteRepository;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -13,23 +19,52 @@ public class SseHeartbeatScheduler {
     private static final String HEARTBEAT_EVENT = "heartbeat";
     private static final String HEARTBEAT_DATA = "ok";
     private static final long HEARTBEAT_INTERVAL_MS = 30_000L;
+    private static final Duration ROUTE_TTL = Duration.ofMinutes(2);
 
     private final SseEmitterRegistry sseEmitterRegistry;
+    private final SseRouteRepository sseRouteRepository;
+    private final SseInstanceIdProvider sseInstanceIdProvider;
 
     @Scheduled(fixedDelay = HEARTBEAT_INTERVAL_MS)
     public void sendHeartbeat() {
+        Set<SseStreamKey> refreshedKeys = new HashSet<>();
+        String instanceId = sseInstanceIdProvider.getInstanceId();
         sseEmitterRegistry.forEachEmitter(
                 (key, emitter) -> {
+                    if (refreshedKeys.add(key)) {
+                        refreshRouteTtl(key, instanceId);
+                    }
                     try {
                         emitter.send(SseEmitter.event().name(HEARTBEAT_EVENT).data(HEARTBEAT_DATA));
                     } catch (Exception ex) {
                         if (SseExceptionUtils.isClientDisconnected(ex)) {
-                            log.debug("[SSE_HEARTBEAT] client_disconnected key={}", key);
+                            log.debug(
+                                    "[SSE_HEARTBEAT] client_disconnected streamType={} streamKey={}",
+                                    key.streamType(),
+                                    key.streamKey());
                         } else {
-                            log.warn("[SSE_HEARTBEAT] send_failed key={}", key, ex);
+                            log.warn(
+                                    "[SSE_HEARTBEAT] send_failed streamType={} streamKey={}",
+                                    key.streamType(),
+                                    key.streamKey(),
+                                    ex);
                         }
                         sseEmitterRegistry.completeWithError(key, emitter, ex);
                     }
                 });
+    }
+
+    private void refreshRouteTtl(SseStreamKey key, String instanceId) {
+        try {
+            sseRouteRepository.upsertRoute(
+                    SseRouteKey.of(key.streamType(), key.streamKey()), instanceId, ROUTE_TTL);
+        } catch (Exception ex) {
+            log.debug(
+                    "[SSE_HEARTBEAT] route_ttl_refresh_failed streamType={} streamKey={} instanceId={}",
+                    key.streamType(),
+                    key.streamKey(),
+                    instanceId,
+                    ex);
+        }
     }
 }

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/SseStreamKey.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/SseStreamKey.java
@@ -1,0 +1,14 @@
+package com.sipomeokjo.commitme.api.sse;
+
+import java.util.Objects;
+
+public record SseStreamKey(String streamType, Long streamKey) {
+    public SseStreamKey {
+        Objects.requireNonNull(streamType, "streamType");
+        Objects.requireNonNull(streamKey, "streamKey");
+    }
+
+    public static SseStreamKey of(String streamType, Long streamKey) {
+        return new SseStreamKey(streamType, streamKey);
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/DefaultSseInstanceIdProvider.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/DefaultSseInstanceIdProvider.java
@@ -1,0 +1,43 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import java.net.InetAddress;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@Slf4j
+public class DefaultSseInstanceIdProvider implements SseInstanceIdProvider {
+    private final String instanceId;
+
+    public DefaultSseInstanceIdProvider(
+            @Value("${app.sse.instance-id:}") String configuredInstanceId) {
+        if (StringUtils.hasText(configuredInstanceId)) {
+            this.instanceId = configuredInstanceId.trim();
+            log.info("[SSE_INSTANCE] configured_instance_id instanceId={}", this.instanceId);
+            return;
+        }
+
+        this.instanceId = buildFallbackInstanceId();
+        log.info("[SSE_INSTANCE] generated_instance_id instanceId={}", this.instanceId);
+    }
+
+    @Override
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    private String buildFallbackInstanceId() {
+        String hostName = "unknown-host";
+        try {
+            hostName = InetAddress.getLocalHost().getHostName();
+        } catch (Exception ex) {
+            log.debug("[SSE_INSTANCE] hostname_lookup_failed", ex);
+        }
+        long pid = ProcessHandle.current().pid();
+        String randomSuffix = UUID.randomUUID().toString().substring(0, 8);
+        return hostName + "-" + pid + "-" + randomSuffix;
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/RedisSseDeliveryBus.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/RedisSseDeliveryBus.java
@@ -1,0 +1,52 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisSseDeliveryBus implements SseDeliveryBus {
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void publish(SseDeliveryEnvelope envelope) {
+        String channel =
+                SseRedisChannelNames.deliveryChannelForInstance(envelope.targetInstanceId());
+        try {
+            String messageBody = objectMapper.writeValueAsString(envelope);
+            Long subscriberCount = stringRedisTemplate.convertAndSend(channel, messageBody);
+            log.debug(
+                    "[SSE_DELIVERY] published targetInstanceId={} streamType={} streamKey={} eventName={} subscriberCount={}",
+                    envelope.targetInstanceId(),
+                    envelope.streamType(),
+                    envelope.streamKey(),
+                    envelope.eventName(),
+                    subscriberCount);
+        } catch (JsonProcessingException ex) {
+            log.warn(
+                    "[SSE_DELIVERY] serialize_failed targetInstanceId={} streamType={} streamKey={} eventName={}",
+                    envelope.targetInstanceId(),
+                    envelope.streamType(),
+                    envelope.streamKey(),
+                    envelope.eventName(),
+                    ex);
+            throw new IllegalArgumentException("Failed to serialize SseDeliveryEnvelope", ex);
+        } catch (RuntimeException ex) {
+            log.warn(
+                    "[SSE_DELIVERY] publish_failed targetInstanceId={} streamType={} streamKey={} eventName={} channel={}",
+                    envelope.targetInstanceId(),
+                    envelope.streamType(),
+                    envelope.streamKey(),
+                    envelope.eventName(),
+                    channel,
+                    ex);
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/RedisSseDeliverySubscriber.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/RedisSseDeliverySubscriber.java
@@ -1,0 +1,61 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisSseDeliverySubscriber implements MessageListener {
+    private final ObjectMapper objectMapper;
+    private final SseInstanceIdProvider sseInstanceIdProvider;
+    private final SseLocalDeliveryDispatcher sseLocalDeliveryDispatcher;
+    private final StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String body = stringRedisSerializer.deserialize(message.getBody());
+
+        if (!StringUtils.hasText(body)) {
+            log.debug("[SSE_DELIVERY_SUBSCRIBER] empty_message_body");
+            return;
+        }
+
+        SseDeliveryEnvelope envelope;
+        try {
+            envelope = objectMapper.readValue(body, SseDeliveryEnvelope.class);
+        } catch (Exception ex) {
+            log.warn("[SSE_DELIVERY_SUBSCRIBER] envelope_parse_failed", ex);
+            return;
+        }
+
+        String localInstanceId = sseInstanceIdProvider.getInstanceId();
+        if (!localInstanceId.equals(envelope.targetInstanceId())) {
+            log.debug(
+                    "[SSE_DELIVERY_SUBSCRIBER] target_mismatch localInstanceId={} targetInstanceId={} streamType={} streamKey={}",
+                    localInstanceId,
+                    envelope.targetInstanceId(),
+                    envelope.streamType(),
+                    envelope.streamKey());
+            return;
+        }
+
+        try {
+            sseLocalDeliveryDispatcher.dispatch(envelope);
+        } catch (Exception ex) {
+            log.warn(
+                    "[SSE_DELIVERY_SUBSCRIBER] dispatch_failed targetInstanceId={} streamType={} streamKey={} eventName={}",
+                    envelope.targetInstanceId(),
+                    envelope.streamType(),
+                    envelope.streamKey(),
+                    envelope.eventName(),
+                    ex);
+        }
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/RedisSseRouteRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/RedisSseRouteRepository.java
@@ -1,0 +1,50 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import java.time.Duration;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisSseRouteRepository implements SseRouteRepository {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void upsertRoute(SseRouteKey routeKey, String instanceId, Duration ttl) {
+        String normalizedInstanceId = normalizeInstanceId(instanceId);
+        validateTtl(ttl);
+
+        String redisKey = SseRedisChannelNames.routeKey(routeKey);
+        stringRedisTemplate.opsForSet().add(redisKey, normalizedInstanceId);
+        stringRedisTemplate.expire(redisKey, ttl);
+    }
+
+    @Override
+    public void removeRoute(SseRouteKey routeKey, String instanceId) {
+        String redisKey = SseRedisChannelNames.routeKey(routeKey);
+        stringRedisTemplate.opsForSet().remove(redisKey, normalizeInstanceId(instanceId));
+    }
+
+    @Override
+    public Set<String> findInstanceIds(SseRouteKey routeKey) {
+        String redisKey = SseRedisChannelNames.routeKey(routeKey);
+        Set<String> instanceIds = stringRedisTemplate.opsForSet().members(redisKey);
+        return instanceIds == null ? Set.of() : Set.copyOf(instanceIds);
+    }
+
+    private String normalizeInstanceId(String instanceId) {
+        if (!StringUtils.hasText(instanceId)) {
+            throw new IllegalArgumentException("instanceId must not be blank");
+        }
+        return instanceId.trim();
+    }
+
+    private void validateTtl(Duration ttl) {
+        if (ttl == null || ttl.isZero() || ttl.isNegative()) {
+            throw new IllegalArgumentException("ttl must be positive");
+        }
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseDeliveryBus.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseDeliveryBus.java
@@ -1,0 +1,5 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+public interface SseDeliveryBus {
+    void publish(SseDeliveryEnvelope envelope);
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseDeliveryEnvelope.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseDeliveryEnvelope.java
@@ -1,0 +1,37 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+import org.springframework.util.StringUtils;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SseDeliveryEnvelope(
+        String sourceInstanceId,
+        String targetInstanceId,
+        String streamType,
+        String streamKey,
+        String eventName,
+        String eventId,
+        JsonNode data,
+        Instant createdAt) {
+    public SseDeliveryEnvelope {
+        sourceInstanceId = requireText(sourceInstanceId, "sourceInstanceId");
+        targetInstanceId = requireText(targetInstanceId, "targetInstanceId");
+        streamType = requireText(streamType, "streamType");
+        streamKey = requireText(streamKey, "streamKey");
+        eventName = requireText(eventName, "eventName");
+        createdAt = createdAt == null ? Instant.now() : createdAt;
+    }
+
+    public SseRouteKey routeKey() {
+        return new SseRouteKey(streamType, streamKey);
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseInstanceIdProvider.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseInstanceIdProvider.java
@@ -1,0 +1,5 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+public interface SseInstanceIdProvider {
+    String getInstanceId();
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseLocalDeliveryDispatcher.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseLocalDeliveryDispatcher.java
@@ -1,0 +1,48 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@Slf4j
+public class SseLocalDeliveryDispatcher {
+    private final Map<String, SseLocalDeliveryHandler> handlersByStreamType;
+
+    public SseLocalDeliveryDispatcher(List<SseLocalDeliveryHandler> handlers) {
+        Map<String, SseLocalDeliveryHandler> map = new LinkedHashMap<>();
+        for (SseLocalDeliveryHandler handler : handlers) {
+            String streamType = normalizeStreamType(handler.streamType());
+            SseLocalDeliveryHandler previous = map.putIfAbsent(streamType, handler);
+            if (previous != null) {
+                log.warn("[SSE_LOCAL_DELIVERY] duplicate_handler streamType={}", streamType);
+                throw new IllegalStateException(
+                        "Duplicate SseLocalDeliveryHandler for streamType=" + streamType);
+            }
+        }
+        this.handlersByStreamType = Map.copyOf(map);
+    }
+
+    public void dispatch(SseDeliveryEnvelope envelope) {
+        SseLocalDeliveryHandler handler = handlersByStreamType.get(envelope.streamType());
+        if (handler == null) {
+            log.warn(
+                    "[SSE_LOCAL_DELIVERY] handler_not_found streamType={} streamKey={} eventName={}",
+                    envelope.streamType(),
+                    envelope.streamKey(),
+                    envelope.eventName());
+            return;
+        }
+        handler.deliver(envelope);
+    }
+
+    private String normalizeStreamType(String streamType) {
+        if (!StringUtils.hasText(streamType)) {
+            throw new IllegalArgumentException("streamType must not be blank");
+        }
+        return streamType.trim();
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseLocalDeliveryHandler.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseLocalDeliveryHandler.java
@@ -1,0 +1,7 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+public interface SseLocalDeliveryHandler {
+    String streamType();
+
+    void deliver(SseDeliveryEnvelope envelope);
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseRedisChannelNames.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseRedisChannelNames.java
@@ -1,0 +1,33 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import org.springframework.util.StringUtils;
+
+public final class SseRedisChannelNames {
+    private static final String ROUTE_KEY_PREFIX = "sse:route";
+    private static final String DELIVERY_CHANNEL_PREFIX = "sse:delivery:instance";
+
+    private SseRedisChannelNames() {}
+
+    public static String routeKey(SseRouteKey routeKey) {
+        return routeKey(routeKey.streamType(), routeKey.streamKey());
+    }
+
+    public static String routeKey(String streamType, String streamKey) {
+        return ROUTE_KEY_PREFIX
+                + ":"
+                + requiredSegment(streamType, "streamType")
+                + ":"
+                + requiredSegment(streamKey, "streamKey");
+    }
+
+    public static String deliveryChannelForInstance(String instanceId) {
+        return DELIVERY_CHANNEL_PREFIX + ":" + requiredSegment(instanceId, "instanceId");
+    }
+
+    private static String requiredSegment(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseRouteKey.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseRouteKey.java
@@ -1,0 +1,21 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import org.springframework.util.StringUtils;
+
+public record SseRouteKey(String streamType, String streamKey) {
+    public SseRouteKey {
+        streamType = requireText(streamType, "streamType");
+        streamKey = requireText(streamKey, "streamKey");
+    }
+
+    public static SseRouteKey of(String streamType, Object streamKey) {
+        return new SseRouteKey(streamType, String.valueOf(streamKey));
+    }
+
+    private static String requireText(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException(fieldName + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseRouteRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/sse/distributed/SseRouteRepository.java
@@ -1,0 +1,12 @@
+package com.sipomeokjo.commitme.api.sse.distributed;
+
+import java.time.Duration;
+import java.util.Set;
+
+public interface SseRouteRepository {
+    void upsertRoute(SseRouteKey routeKey, String instanceId, Duration ttl);
+
+    void removeRoute(SseRouteKey routeKey, String instanceId);
+
+    Set<String> findInstanceIds(SseRouteKey routeKey);
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/notification/service/NotificationSseService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/notification/service/NotificationSseService.java
@@ -4,9 +4,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sipomeokjo.commitme.api.sse.SseEmitterRegistry;
 import com.sipomeokjo.commitme.api.sse.SseExceptionUtils;
+import com.sipomeokjo.commitme.api.sse.SseStreamKey;
+import com.sipomeokjo.commitme.api.sse.distributed.SseDeliveryBus;
+import com.sipomeokjo.commitme.api.sse.distributed.SseDeliveryEnvelope;
+import com.sipomeokjo.commitme.api.sse.distributed.SseInstanceIdProvider;
+import com.sipomeokjo.commitme.api.sse.distributed.SseLocalDeliveryHandler;
+import com.sipomeokjo.commitme.api.sse.distributed.SseRouteKey;
+import com.sipomeokjo.commitme.api.sse.distributed.SseRouteRepository;
 import com.sipomeokjo.commitme.domain.notification.dto.NotificationSsePayload;
 import com.sipomeokjo.commitme.domain.notification.entity.Notification;
 import com.sipomeokjo.commitme.domain.notification.repository.NotificationRepository;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,14 +24,23 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class NotificationSseService {
+public class NotificationSseService implements SseLocalDeliveryHandler {
+    private static final String STREAM_TYPE_NOTIFICATION = "notification";
+    private static final String EVENT_NOTIFICATION = "notification";
+    private static final Duration ROUTE_TTL = Duration.ofMinutes(2);
+
     private final NotificationRepository notificationRepository;
     private final NotificationBadgeService notificationBadgeService;
     private final ObjectMapper objectMapper;
     private final SseEmitterRegistry sseEmitterRegistry;
+    private final SseRouteRepository sseRouteRepository;
+    private final SseDeliveryBus sseDeliveryBus;
+    private final SseInstanceIdProvider sseInstanceIdProvider;
 
     public SseEmitter subscribe(Long userId, String lastEventId) {
-        SseEmitter emitter = sseEmitterRegistry.register(userId);
+        SseStreamKey streamKey = streamKey(userId);
+        SseEmitter emitter = sseEmitterRegistry.register(streamKey);
+        refreshRouteTtl(streamKey);
 
         try {
             emitter.send(
@@ -37,7 +54,7 @@ public class NotificationSseService {
             } else {
                 log.warn("[NOTIFICATION_SSE] connected_event_failed userId={}", userId, ex);
             }
-            sseEmitterRegistry.completeWithError(userId, emitter, ex);
+            sseEmitterRegistry.completeWithError(streamKey, emitter, ex);
             return emitter;
         }
 
@@ -54,38 +71,167 @@ public class NotificationSseService {
             return;
         }
         Long userId = notification.getUser().getId();
-        List<SseEmitter> emitters = sseEmitterRegistry.getEmitters(userId);
-        if (emitters == null || emitters.isEmpty()) {
+        if (userId == null) {
             return;
         }
 
         NotificationSsePayload payload = toPayload(notification);
+        sendDistributed(
+                userId, String.valueOf(notification.getId()), payload, notification.getId());
+    }
+
+    @Override
+    public String streamType() {
+        return STREAM_TYPE_NOTIFICATION;
+    }
+
+    @Override
+    public void deliver(SseDeliveryEnvelope envelope) {
+        if (envelope == null) {
+            return;
+        }
+        if (!EVENT_NOTIFICATION.equals(envelope.eventName())) {
+            return;
+        }
+
+        Long userId = parseUserId(envelope.streamKey());
+        if (userId == null) {
+            return;
+        }
+
+        NotificationSsePayload payload;
+        try {
+            if (envelope.data() == null) {
+                return;
+            }
+            payload = objectMapper.treeToValue(envelope.data(), NotificationSsePayload.class);
+        } catch (Exception ex) {
+            log.warn(
+                    "[NOTIFICATION_SSE] remote_payload_parse_failed streamKey={} eventName={}",
+                    envelope.streamKey(),
+                    envelope.eventName(),
+                    ex);
+            return;
+        }
+
+        sendLocalOnly(userId, envelope.eventName(), envelope.eventId(), payload, payload.id());
+    }
+
+    private void sendDistributed(
+            Long userId, String eventId, NotificationSsePayload payload, Long notificationId) {
+        SseStreamKey localStreamKey = streamKey(userId);
+        SseRouteKey routeKey = routeKey(userId);
+        String localInstanceId = sseInstanceIdProvider.getInstanceId();
+
+        java.util.Set<String> instanceIds;
+        try {
+            instanceIds = sseRouteRepository.findInstanceIds(routeKey);
+        } catch (Exception ex) {
+            log.warn("[NOTIFICATION_SSE] route_lookup_failed userId={}", userId, ex);
+            sendLocalOnly(
+                    userId,
+                    NotificationSseService.EVENT_NOTIFICATION,
+                    eventId,
+                    payload,
+                    notificationId);
+            return;
+        }
+
+        if (instanceIds.isEmpty()) {
+            sendLocalOnly(
+                    userId,
+                    NotificationSseService.EVENT_NOTIFICATION,
+                    eventId,
+                    payload,
+                    notificationId);
+            return;
+        }
+
+        JsonNode payloadNode = objectMapper.valueToTree(payload);
+        boolean localDelivered = false;
+        for (String instanceId : instanceIds) {
+            if (localInstanceId.equals(instanceId)) {
+                sendLocalOnly(
+                        userId,
+                        NotificationSseService.EVENT_NOTIFICATION,
+                        eventId,
+                        payload,
+                        notificationId);
+                localDelivered = true;
+                continue;
+            }
+
+            try {
+                sseDeliveryBus.publish(
+                        new SseDeliveryEnvelope(
+                                localInstanceId,
+                                instanceId,
+                                STREAM_TYPE_NOTIFICATION,
+                                String.valueOf(userId),
+                                NotificationSseService.EVENT_NOTIFICATION,
+                                eventId,
+                                payloadNode,
+                                null));
+            } catch (Exception ex) {
+                log.warn(
+                        "[NOTIFICATION_SSE] remote_publish_failed userId={} notificationId={} targetInstanceId={}",
+                        userId,
+                        notificationId,
+                        instanceId,
+                        ex);
+            }
+        }
+
+        if (!localDelivered && sseEmitterRegistry.count(localStreamKey) > 0) {
+            sendLocalOnly(
+                    userId,
+                    NotificationSseService.EVENT_NOTIFICATION,
+                    eventId,
+                    payload,
+                    notificationId);
+        }
+    }
+
+    private void sendLocalOnly(
+            Long userId,
+            String eventName,
+            String eventId,
+            NotificationSsePayload payload,
+            Long notificationId) {
+        SseStreamKey streamKey = streamKey(userId);
+        List<SseEmitter> emitters = sseEmitterRegistry.getEmitters(streamKey);
+        if (emitters == null || emitters.isEmpty()) {
+            return;
+        }
+
         for (SseEmitter emitter : emitters) {
             try {
-                emitter.send(
-                        SseEmitter.event()
-                                .id(String.valueOf(notification.getId()))
-                                .name("notification")
-                                .data(payload));
+                SseEmitter.SseEventBuilder eventBuilder =
+                        SseEmitter.event().name(eventName).data(payload);
+                if (eventId != null && !eventId.isBlank()) {
+                    eventBuilder.id(eventId);
+                }
+                emitter.send(eventBuilder);
             } catch (Exception ex) {
                 if (SseExceptionUtils.isClientDisconnected(ex)) {
                     log.debug(
                             "[NOTIFICATION_SSE] client_disconnected userId={} notificationId={}",
                             userId,
-                            notification.getId());
+                            notificationId);
                 } else {
                     log.warn(
                             "[NOTIFICATION_SSE] send_failed userId={} notificationId={}",
                             userId,
-                            notification.getId(),
+                            notificationId,
                             ex);
                 }
-                sseEmitterRegistry.completeWithError(userId, emitter, ex);
+                sseEmitterRegistry.completeWithError(streamKey, emitter, ex);
             }
         }
     }
 
     private void replay(Long userId, Long lastEventId, SseEmitter emitter) {
+        SseStreamKey streamKey = streamKey(userId);
         List<Notification> notifications =
                 notificationRepository.findByUser_IdAndIdGreaterThanOrderByIdAsc(
                         userId, lastEventId);
@@ -112,9 +258,41 @@ public class NotificationSseService {
                             notification.getId(),
                             ex);
                 }
-                sseEmitterRegistry.completeWithError(userId, emitter, ex);
+                sseEmitterRegistry.completeWithError(streamKey, emitter, ex);
                 return;
             }
+        }
+    }
+
+    private SseStreamKey streamKey(Long userId) {
+        return SseStreamKey.of(STREAM_TYPE_NOTIFICATION, userId);
+    }
+
+    private SseRouteKey routeKey(Long userId) {
+        return SseRouteKey.of(STREAM_TYPE_NOTIFICATION, userId);
+    }
+
+    private void refreshRouteTtl(SseStreamKey streamKey) {
+        try {
+            sseRouteRepository.upsertRoute(
+                    SseRouteKey.of(streamKey.streamType(), streamKey.streamKey()),
+                    sseInstanceIdProvider.getInstanceId(),
+                    ROUTE_TTL);
+        } catch (Exception ex) {
+            log.debug(
+                    "[NOTIFICATION_SSE] route_ttl_refresh_failed streamType={} streamKey={}",
+                    streamKey.streamType(),
+                    streamKey.streamKey(),
+                    ex);
+        }
+    }
+
+    private Long parseUserId(String streamKey) {
+        try {
+            return Long.parseLong(streamKey);
+        } catch (Exception ex) {
+            log.warn("[NOTIFICATION_SSE] stream_key_invalid streamKey={}", streamKey, ex);
+            return null;
         }
     }
 

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeSseService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeSseService.java
@@ -1,11 +1,21 @@
 package com.sipomeokjo.commitme.domain.resume.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sipomeokjo.commitme.api.sse.SseEmitterRegistry;
 import com.sipomeokjo.commitme.api.sse.SseExceptionUtils;
+import com.sipomeokjo.commitme.api.sse.SseStreamKey;
+import com.sipomeokjo.commitme.api.sse.distributed.SseDeliveryBus;
+import com.sipomeokjo.commitme.api.sse.distributed.SseDeliveryEnvelope;
+import com.sipomeokjo.commitme.api.sse.distributed.SseInstanceIdProvider;
+import com.sipomeokjo.commitme.api.sse.distributed.SseLocalDeliveryHandler;
+import com.sipomeokjo.commitme.api.sse.distributed.SseRouteKey;
+import com.sipomeokjo.commitme.api.sse.distributed.SseRouteRepository;
 import com.sipomeokjo.commitme.domain.resume.dto.ResumeEditFailedSsePayload;
 import com.sipomeokjo.commitme.domain.resume.dto.ResumeEditSsePayload;
 import com.sipomeokjo.commitme.domain.resume.event.ResumeEditCompletedEvent;
 import com.sipomeokjo.commitme.domain.resume.event.ResumeEditFailedEvent;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,11 +27,22 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ResumeSseService {
+public class ResumeSseService implements SseLocalDeliveryHandler {
+    private static final String STREAM_TYPE_RESUME = "resume";
+    private static final String EVENT_EDIT_COMPLETE = "resume-edit-complete";
+    private static final String EVENT_EDIT_FAILED = "resume-edit-failed";
+    private static final Duration ROUTE_TTL = Duration.ofMinutes(2);
+
     private final SseEmitterRegistry sseEmitterRegistry;
+    private final ObjectMapper objectMapper;
+    private final SseRouteRepository sseRouteRepository;
+    private final SseDeliveryBus sseDeliveryBus;
+    private final SseInstanceIdProvider sseInstanceIdProvider;
 
     public SseEmitter subscribe(Long resumeId) {
-        SseEmitter emitter = sseEmitterRegistry.register(resumeId);
+        SseStreamKey streamKey = streamKey(resumeId);
+        SseEmitter emitter = sseEmitterRegistry.register(streamKey);
+        refreshRouteTtl(streamKey);
 
         try {
             emitter.send(SseEmitter.event().name("connected").data("ok"));
@@ -32,7 +53,7 @@ public class ResumeSseService {
             } else {
                 log.warn("[RESUME_SSE] connected_event_failed resumeId={}", resumeId, ex);
             }
-            sseEmitterRegistry.completeWithError(resumeId, emitter, ex);
+            sseEmitterRegistry.completeWithError(streamKey, emitter, ex);
         }
 
         return emitter;
@@ -47,42 +68,9 @@ public class ResumeSseService {
         if (resumeId == null) {
             return;
         }
-        List<SseEmitter> emitters = sseEmitterRegistry.getEmitters(resumeId);
-        if (emitters == null || emitters.isEmpty()) {
-            log.debug("[RESUME_SSE] no_emitters resumeId={}", resumeId);
-            return;
-        }
-
         ResumeEditSsePayload payload =
                 new ResumeEditSsePayload(resumeId, versionNo, taskId, updatedAt, resumePayload);
-
-        log.debug(
-                "[RESUME_SSE] send_edit_completed resumeId={} versionNo={} taskId={} emitters={}",
-                resumeId,
-                versionNo,
-                taskId,
-                emitters.size());
-        for (SseEmitter emitter : emitters) {
-            try {
-                emitter.send(SseEmitter.event().name("resume-edit-complete").data(payload));
-            } catch (Exception ex) {
-                if (SseExceptionUtils.isClientDisconnected(ex)) {
-                    log.debug(
-                            "[RESUME_SSE] client_disconnected resumeId={} versionNo={} taskId={}",
-                            resumeId,
-                            versionNo,
-                            taskId);
-                } else {
-                    log.warn(
-                            "[RESUME_SSE] send_failed resumeId={} versionNo={} taskId={}",
-                            resumeId,
-                            versionNo,
-                            taskId,
-                            ex);
-                }
-                sseEmitterRegistry.completeWithError(resumeId, emitter, ex);
-            }
-        }
+        sendDistributed(resumeId, EVENT_EDIT_COMPLETE, payload, versionNo, taskId);
     }
 
     public void sendEditFailed(
@@ -95,19 +83,135 @@ public class ResumeSseService {
         if (resumeId == null) {
             return;
         }
-        List<SseEmitter> emitters = sseEmitterRegistry.getEmitters(resumeId);
+        ResumeEditFailedSsePayload payload =
+                new ResumeEditFailedSsePayload(
+                        resumeId, versionNo, taskId, updatedAt, errorCode, errorMessage);
+        sendDistributed(resumeId, EVENT_EDIT_FAILED, payload, versionNo, taskId);
+    }
+
+    @Override
+    public String streamType() {
+        return STREAM_TYPE_RESUME;
+    }
+
+    @Override
+    public void deliver(SseDeliveryEnvelope envelope) {
+        if (envelope == null) {
+            return;
+        }
+
+        Long resumeId = parseResumeId(envelope.streamKey());
+        if (resumeId == null) {
+            return;
+        }
+        if (envelope.data() == null) {
+            return;
+        }
+
+        try {
+            if (EVENT_EDIT_COMPLETE.equals(envelope.eventName())) {
+                ResumeEditSsePayload payload =
+                        objectMapper.treeToValue(envelope.data(), ResumeEditSsePayload.class);
+                sendLocalOnly(
+                        resumeId,
+                        EVENT_EDIT_COMPLETE,
+                        payload,
+                        payload.versionNo(),
+                        payload.taskId());
+                return;
+            }
+            if (EVENT_EDIT_FAILED.equals(envelope.eventName())) {
+                ResumeEditFailedSsePayload payload =
+                        objectMapper.treeToValue(envelope.data(), ResumeEditFailedSsePayload.class);
+                sendLocalOnly(
+                        resumeId,
+                        EVENT_EDIT_FAILED,
+                        payload,
+                        payload.versionNo(),
+                        payload.taskId());
+                return;
+            }
+        } catch (Exception ex) {
+            log.warn(
+                    "[RESUME_SSE] remote_payload_parse_failed resumeId={} eventName={}",
+                    resumeId,
+                    envelope.eventName(),
+                    ex);
+        }
+    }
+
+    private SseStreamKey streamKey(Long resumeId) {
+        return SseStreamKey.of(STREAM_TYPE_RESUME, resumeId);
+    }
+
+    private void sendDistributed(
+            Long resumeId, String eventName, Object payload, Integer versionNo, String taskId) {
+        SseStreamKey localStreamKey = streamKey(resumeId);
+        SseRouteKey routeKey = routeKey(resumeId);
+        String localInstanceId = sseInstanceIdProvider.getInstanceId();
+
+        java.util.Set<String> instanceIds;
+        try {
+            instanceIds = sseRouteRepository.findInstanceIds(routeKey);
+        } catch (Exception ex) {
+            log.warn("[RESUME_SSE] route_lookup_failed resumeId={}", resumeId, ex);
+            sendLocalOnly(resumeId, eventName, payload, versionNo, taskId);
+            return;
+        }
+
+        if (instanceIds.isEmpty()) {
+            sendLocalOnly(resumeId, eventName, payload, versionNo, taskId);
+            return;
+        }
+
+        JsonNode payloadNode = objectMapper.valueToTree(payload);
+        boolean localDelivered = false;
+
+        for (String instanceId : instanceIds) {
+            if (localInstanceId.equals(instanceId)) {
+                sendLocalOnly(resumeId, eventName, payload, versionNo, taskId);
+                localDelivered = true;
+                continue;
+            }
+            try {
+                sseDeliveryBus.publish(
+                        new SseDeliveryEnvelope(
+                                localInstanceId,
+                                instanceId,
+                                STREAM_TYPE_RESUME,
+                                String.valueOf(resumeId),
+                                eventName,
+                                null,
+                                payloadNode,
+                                null));
+            } catch (Exception ex) {
+                log.warn(
+                        "[RESUME_SSE] remote_publish_failed resumeId={} versionNo={} taskId={} targetInstanceId={}",
+                        resumeId,
+                        versionNo,
+                        taskId,
+                        instanceId,
+                        ex);
+            }
+        }
+
+        if (!localDelivered && sseEmitterRegistry.count(localStreamKey) > 0) {
+            sendLocalOnly(resumeId, eventName, payload, versionNo, taskId);
+        }
+    }
+
+    private void sendLocalOnly(
+            Long resumeId, String eventName, Object payload, Integer versionNo, String taskId) {
+        SseStreamKey streamKey = streamKey(resumeId);
+        List<SseEmitter> emitters = sseEmitterRegistry.getEmitters(streamKey);
         if (emitters == null || emitters.isEmpty()) {
             log.debug("[RESUME_SSE] no_emitters resumeId={}", resumeId);
             return;
         }
 
-        ResumeEditFailedSsePayload payload =
-                new ResumeEditFailedSsePayload(
-                        resumeId, versionNo, taskId, updatedAt, errorCode, errorMessage);
-
         for (SseEmitter emitter : emitters) {
             try {
-                emitter.send(SseEmitter.event().name("resume-edit-failed").data(payload));
+                emitter.send(SseEmitter.event().name(eventName).data(payload));
             } catch (Exception ex) {
                 if (SseExceptionUtils.isClientDisconnected(ex)) {
                     log.debug(
@@ -123,8 +227,36 @@ public class ResumeSseService {
                             taskId,
                             ex);
                 }
-                sseEmitterRegistry.completeWithError(resumeId, emitter, ex);
+                sseEmitterRegistry.completeWithError(streamKey, emitter, ex);
             }
+        }
+    }
+
+    private SseRouteKey routeKey(Long resumeId) {
+        return SseRouteKey.of(STREAM_TYPE_RESUME, resumeId);
+    }
+
+    private void refreshRouteTtl(SseStreamKey streamKey) {
+        try {
+            sseRouteRepository.upsertRoute(
+                    SseRouteKey.of(streamKey.streamType(), streamKey.streamKey()),
+                    sseInstanceIdProvider.getInstanceId(),
+                    ROUTE_TTL);
+        } catch (Exception ex) {
+            log.debug(
+                    "[RESUME_SSE] route_ttl_refresh_failed streamType={} streamKey={}",
+                    streamKey.streamType(),
+                    streamKey.streamKey(),
+                    ex);
+        }
+    }
+
+    private Long parseResumeId(String streamKey) {
+        try {
+            return Long.parseLong(streamKey);
+        } catch (Exception ex) {
+            log.warn("[RESUME_SSE] stream_key_invalid streamKey={}", streamKey, ex);
+            return null;
         }
     }
 


### PR DESCRIPTION
### Description

Redis와 Redis Pub/Sub를 사용하여 다중 서버 인스턴스에서 SSE 알림 전송을 보장합니다.

### Related Issues

- Resolves #151

### Changes Made

1. SSE 키 구조를 단일 Long 키에서 `SseStreamKey(streamType, streamKey)`로 변경
  - 각자 다른 emitter 이름 충돌을 우려하여 변경
2. SSE 연결 시 로직 수정
  - subscribe 시 Redis에 route upsert 진행 (`sse:route`, `sse:delivery:instance`)
  - 하나의 stream key에 여러 인스턴스 동시 연결이 필요하므로 SET 자료 구조 사용
4. `SseDeliveryBus` 인터페이스 및 `RedisSsePublishBus` 구현
  - envelope JSON 직렬화 및 Redis Pub/Sub 발행 담당
5. `RedisSseDeliverySubscriber`
  - Redis message body 역직렬화 및 파싱, `targetInstanceId` 확인 후 로컬 디스패처로 전달
6. `SseLocalDeliveryDispatcher`
  - streamType별 map에 `SseLocalDeliveryHandler`를 등록하여 관리
7. Redis Pub/Sub로 타겟 인스턴스에 전달
  - subscribe 시 로컬 registry 등록, Redis 내 route upsert 및 TTL 갱신, connected 이벤트 전송, Last-Event-Id 헤더가 있는 경우 파싱 후 재처리
  - send 시 notification userId 확인 후 payload 생성, Redis route 조회 후 결과에 따라 로컬 인스턴스 -> 로컬 emitter 목록 조회하여 전달 혹은 리모트 인스턴스로 전달

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.