### PR TITLE
fix: AccessToken 발급 시 캐시로 인해 상태 값을 잘못 발급하는 문제 수정

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandService.java
@@ -121,7 +121,7 @@ public class AuthCommandService {
             if (!revoked) {
                 throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
             }
-            UserStatus status = UserStatus.valueOf(cached.getUserStatus());
+            UserStatus status = resolveCurrentUserStatus(cached.getUserId());
             return authSessionIssueService.issueTokens(cached.getUserId(), status);
         }
 
@@ -185,6 +185,13 @@ public class AuthCommandService {
             log.warn("[Auth][FetchUser] 사용자 조회 실패: 사유=응답 없음 또는 id 누락, response={}", response);
         }
         return response;
+    }
+
+    private UserStatus resolveCurrentUserStatus(Long userId) {
+        return userRepository
+                .findById(userId)
+                .map(User::getStatus)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
     }
 
     private String normalizeScopes(String scope) {

--- a/src/main/java/com/sipomeokjo/commitme/security/jwt/JwtFilter.java
+++ b/src/main/java/com/sipomeokjo/commitme/security/jwt/JwtFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -86,11 +87,49 @@ public class JwtFilter extends OncePerRequestFilter {
             return null;
         }
 
-        return Arrays.stream(cookies)
-                .filter(cookie -> cookie.getName().equals("access_token"))
-                .map(Cookie::getValue)
-                .filter(value -> !value.isBlank())
-                .findFirst()
-                .orElse(null);
+        List<String> candidates =
+                Arrays.stream(cookies)
+                        .filter(cookie -> cookie.getName().equals("access_token"))
+                        .map(Cookie::getValue)
+                        .filter(value -> !value.isBlank())
+                        .toList();
+
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        if (candidates.size() == 1) {
+            return candidates.getFirst();
+        }
+
+        log.debug(
+                "[JWT] duplicated_access_token_cookie method={} uri={} count={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                candidates.size());
+        return selectLatestIssuedToken(candidates);
+    }
+
+    private String selectLatestIssuedToken(List<String> candidates) {
+        String selectedToken = null;
+        Instant selectedIssuedAt = null;
+
+        for (String candidate : candidates) {
+            if (!tokenProvider.validateToken(candidate)) {
+                continue;
+            }
+
+            Instant issuedAt = tokenProvider.getIssuedAt(candidate);
+            if (issuedAt == null) {
+                continue;
+            }
+
+            if (selectedToken == null || issuedAt.isAfter(selectedIssuedAt)) {
+                selectedToken = candidate;
+                selectedIssuedAt = issuedAt;
+            }
+        }
+
+        return selectedToken != null ? selectedToken : candidates.getFirst();
     }
 }


### PR DESCRIPTION
### Description

AccessToken을 발급할 때 캐시로 인해서 변경된 값이 아닌 UserStatus를 지속적으로 사용 중이던 문제를 해결합니다.

### Changes Made

1. AccessToken 재발급 시 데이터베이스에서 UserStatus를 선 조회
2. AccessToken이 여러 개인 경우, 제일 최신에 생성된 것을 선택하여 검증

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.