### PR TITLE
fix: 유저 탈퇴 후 1일 뒤, 재가입 가능하도록 수정

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/api/response/ErrorCode.java
+++ b/src/main/java/com/sipomeokjo/commitme/api/response/ErrorCode.java
@@ -92,7 +92,7 @@ public enum ErrorCode implements ResponseCode {
     // OAUTH
     OAUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "OAUTH_ACCESS_DENIED", "소셜 로그인 권한이 거부되었습니다."),
     OAUTH_ACCOUNT_WITHDRAWN(
-            HttpStatus.FORBIDDEN, "OAUTH_ACCOUNT_WITHDRAWN", "탈퇴한 계정입니다. 30일 후 재가입 가능합니다."),
+            HttpStatus.FORBIDDEN, "OAUTH_ACCOUNT_WITHDRAWN", "탈퇴한 계정입니다. 1일 후 재가입 가능합니다."),
 
     // 페이지네이션
     INVALID_CURSOR_VALUE(HttpStatus.BAD_REQUEST, "INVALID_CURSOR_VALUE", "커서 값이 유효하지 않거나 손상되었습니다."),

--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/entity/Auth.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/entity/Auth.java
@@ -89,4 +89,8 @@ public class Auth extends BaseEntity {
         this.tokenScopes = null;
         this.tokenExpiresAt = null;
     }
+
+    public void rebindUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/repository/AuthRepository.java
@@ -2,14 +2,25 @@ package com.sipomeokjo.commitme.domain.auth.repository;
 
 import com.sipomeokjo.commitme.domain.auth.entity.Auth;
 import com.sipomeokjo.commitme.domain.auth.entity.AuthProvider;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AuthRepository extends JpaRepository<Auth, Long> {
     Optional<Auth> findByProviderAndProviderUserId(AuthProvider provider, String providerUserId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+            "SELECT a FROM Auth a WHERE a.provider = :provider AND a.providerUserId = :providerUserId")
+    Optional<Auth> findByProviderAndProviderUserIdWithLock(
+            @Param("provider") AuthProvider provider,
+            @Param("providerUserId") String providerUserId);
 
     Optional<Auth> findByUser_IdAndProvider(Long userId, AuthProvider provider);
 

--- a/src/test/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandServiceTest.java
@@ -1,0 +1,192 @@
+package com.sipomeokjo.commitme.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.auth.config.GithubProperties;
+import com.sipomeokjo.commitme.domain.auth.dto.AuthLoginResult;
+import com.sipomeokjo.commitme.domain.auth.dto.AuthTokenReissueResult;
+import com.sipomeokjo.commitme.domain.auth.dto.GithubAccessTokenResponse;
+import com.sipomeokjo.commitme.domain.auth.dto.GithubUserResponse;
+import com.sipomeokjo.commitme.domain.auth.entity.Auth;
+import com.sipomeokjo.commitme.domain.auth.entity.AuthProvider;
+import com.sipomeokjo.commitme.domain.auth.repository.AuthRepository;
+import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
+import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheService;
+import com.sipomeokjo.commitme.domain.user.entity.User;
+import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
+import com.sipomeokjo.commitme.domain.user.repository.UserRepository;
+import com.sipomeokjo.commitme.domain.userSetting.entity.UserSetting;
+import com.sipomeokjo.commitme.domain.userSetting.repository.UserSettingRepository;
+import com.sipomeokjo.commitme.security.jwt.AccessTokenCipher;
+import com.sipomeokjo.commitme.security.jwt.RefreshTokenProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AuthCommandServiceTest {
+
+    @Mock private AuthRepository authRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private UserSettingRepository userSettingRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private RefreshTokenCacheService refreshTokenCacheService;
+    @Mock private AuthSessionIssueService authSessionIssueService;
+    @Mock private AccessTokenCipher accessTokenCipher;
+    @Mock private RefreshTokenProvider refreshTokenProvider;
+    @Mock private GithubProperties githubProperties;
+    @Mock private RestClient githubOAuthClient;
+    @Mock private RestClient githubApiClient;
+    @Mock private RestClient.RequestBodyUriSpec oauthPostSpec;
+    @Mock private RestClient.RequestBodySpec oauthBodySpec;
+    @Mock private RestClient.RequestHeadersUriSpec apiGetSpec;
+    @Mock private RestClient.RequestHeadersSpec apiHeadersSpec;
+    @Mock private RestClient.ResponseSpec oauthResponseSpec;
+    @Mock private RestClient.ResponseSpec apiResponseSpec;
+
+    private Clock clock;
+    private AuthCommandService authCommandService;
+
+    @BeforeEach
+    void setUp() {
+        clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneOffset.UTC);
+        authCommandService =
+                new AuthCommandService(
+                        authRepository,
+                        userRepository,
+                        userSettingRepository,
+                        refreshTokenRepository,
+                        refreshTokenCacheService,
+                        authSessionIssueService,
+                        accessTokenCipher,
+                        refreshTokenProvider,
+                        githubProperties,
+                        clock,
+                        githubOAuthClient,
+                        githubApiClient);
+
+        given(githubProperties.getClientId()).willReturn("client-id");
+        given(githubProperties.getClientSecret()).willReturn("client-secret");
+        given(githubProperties.getRedirectUri()).willReturn("https://example.com/callback");
+        given(accessTokenCipher.encrypt(anyString())).willReturn("enc-token");
+    }
+
+    @Test
+    void loginWithGithub_inactiveUserBeforeOneDay_throwsWithdrawn() {
+        User inactiveUser =
+                User.builder()
+                        .id(10L)
+                        .status(UserStatus.INACTIVE)
+                        .deletedAt(Instant.parse("2026-02-28T12:00:01Z"))
+                        .build();
+        Auth auth =
+                Auth.builder()
+                        .id(1L)
+                        .provider(AuthProvider.GITHUB)
+                        .providerUserId("100")
+                        .user(inactiveUser)
+                        .build();
+
+        stubGithubExchangeAndFetch("oauth-access-token", 100L, "octocat");
+        given(authRepository.findByProviderAndProviderUserIdWithLock(AuthProvider.GITHUB, "100"))
+                .willReturn(Optional.of(auth));
+
+        assertThatThrownBy(() -> authCommandService.loginWithGithub("code"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.OAUTH_ACCOUNT_WITHDRAWN);
+    }
+
+    @Test
+    void loginWithGithub_inactiveUserAfterOneDay_createsNewPendingUserAndRebindsAuth() {
+        User oldUser =
+                User.builder()
+                        .id(10L)
+                        .status(UserStatus.INACTIVE)
+                        .deletedAt(Instant.parse("2026-02-27T23:59:59Z"))
+                        .build();
+        Auth auth =
+                Auth.builder()
+                        .id(1L)
+                        .provider(AuthProvider.GITHUB)
+                        .providerUserId("200")
+                        .providerUsername("old-name")
+                        .user(oldUser)
+                        .build();
+
+        stubGithubExchangeAndFetch("oauth-access-token", 200L, "new-name");
+        given(authRepository.findByProviderAndProviderUserIdWithLock(AuthProvider.GITHUB, "200"))
+                .willReturn(Optional.of(auth));
+
+        AtomicLong userIdSequence = new AtomicLong(1000L);
+        given(userRepository.save(any(User.class)))
+                .willAnswer(
+                        invocation -> {
+                            User source = invocation.getArgument(0);
+                            return User.builder()
+                                    .id(userIdSequence.incrementAndGet())
+                                    .status(source.getStatus())
+                                    .deletedAt(source.getDeletedAt())
+                                    .build();
+                        });
+        given(userSettingRepository.save(any(UserSetting.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(authSessionIssueService.issueTokens(eq(1001L), eq(UserStatus.PENDING)))
+                .willReturn(new AuthTokenReissueResult("new-access", "new-refresh"));
+
+        AuthLoginResult result = authCommandService.loginWithGithub("code");
+
+        assertThat(result.onboardingCompleted()).isFalse();
+        assertThat(result.accessToken()).isEqualTo("new-access");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh");
+        assertThat(auth.getUser().getId()).isEqualTo(1001L);
+        assertThat(auth.getUser().getStatus()).isEqualTo(UserStatus.PENDING);
+        assertThat(oldUser.getId()).isEqualTo(10L);
+        assertThat(oldUser.getStatus()).isEqualTo(UserStatus.INACTIVE);
+
+        verify(userSettingRepository).save(any(UserSetting.class));
+        verify(authSessionIssueService).issueTokens(1001L, UserStatus.PENDING);
+    }
+
+    private void stubGithubExchangeAndFetch(String accessToken, Long githubUserId, String login) {
+        given(githubOAuthClient.post()).willReturn(oauthPostSpec);
+        given(oauthPostSpec.uri("/login/oauth/access_token")).willReturn(oauthBodySpec);
+        given(oauthBodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .willReturn(oauthBodySpec);
+        given(oauthBodySpec.accept(MediaType.APPLICATION_JSON)).willReturn(oauthBodySpec);
+        doReturn(oauthBodySpec).when(oauthBodySpec).body(any(MultiValueMap.class));
+        given(oauthBodySpec.retrieve()).willReturn(oauthResponseSpec);
+        given(oauthResponseSpec.body(GithubAccessTokenResponse.class))
+                .willReturn(new GithubAccessTokenResponse(accessToken, "bearer", "repo user"));
+
+        given(githubApiClient.get()).willReturn(apiGetSpec);
+        given(apiGetSpec.uri("/user")).willReturn(apiHeadersSpec);
+        given(apiHeadersSpec.header("Authorization", "Bearer " + accessToken))
+                .willReturn(apiHeadersSpec);
+        given(apiHeadersSpec.retrieve()).willReturn(apiResponseSpec);
+        given(apiResponseSpec.body(GithubUserResponse.class))
+                .willReturn(new GithubUserResponse(githubUserId, login, null, null, null));
+    }
+}


### PR DESCRIPTION
### Description

유저가 탈퇴하고 1일 뒤 재가입이 가능하도록 수정하였습니다.

### Changes Made

1. 재가입을 위한 대기 기간 변경
2. 기존 계정 정보와 데이터가 섞이지 않도록 새로운 User record 생성

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.