### PR TITLE
refactor: RefreshToken Redis 캐시 갱신을 트랜잭션 밖으로 이동

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandService.java
@@ -10,8 +10,6 @@ import com.sipomeokjo.commitme.domain.auth.dto.GithubUserResponse;
 import com.sipomeokjo.commitme.domain.auth.entity.Auth;
 import com.sipomeokjo.commitme.domain.auth.entity.AuthProvider;
 import com.sipomeokjo.commitme.domain.auth.repository.AuthRepository;
-import com.sipomeokjo.commitme.domain.refreshToken.entity.RefreshToken;
-import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
 import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheService;
 import com.sipomeokjo.commitme.domain.user.entity.User;
 import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
@@ -31,22 +29,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class AuthCommandService {
 
     private final AuthRepository authRepository;
     private final UserRepository userRepository;
     private final UserSettingRepository userSettingRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final RefreshTokenCacheService refreshTokenCacheService;
+    private final TransactionOperations transactionOperations;
     private final AuthSessionIssueService authSessionIssueService;
     private final AccessTokenCipher accessTokenCipher;
     private final RefreshTokenProvider refreshTokenProvider;
@@ -70,6 +67,17 @@ public class AuthCommandService {
             throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
         }
 
+        AuthLoginResult result =
+                transactionOperations.execute(
+                        status -> loginWithGithubInternal(tokenResponse, githubUser));
+        if (result == null) {
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+        return result;
+    }
+
+    private AuthLoginResult loginWithGithubInternal(
+            GithubAccessTokenResponse tokenResponse, GithubUserResponse githubUser) {
         Auth auth =
                 authRepository
                         .findByProviderAndProviderUserIdWithLock(
@@ -187,24 +195,12 @@ public class AuthCommandService {
                 meterRegistry
                         .counter("auth_token_reissue_cache_lookup_total", "result", "expired")
                         .increment();
-                refreshTokenCacheService.evict(tokenHash);
             } else {
                 meterRegistry
                         .counter("auth_token_reissue_cache_lookup_total", "result", "hit")
                         .increment();
-                boolean revoked = authSessionIssueService.revokeRefreshToken(refreshToken);
-                if (!revoked) {
-                    log.warn(
-                            "[Auth][TokenReissue] cached_token_revoke_failed tokenHashFingerprint={}",
-                            fingerprint(tokenHash));
-                    throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
-                }
-                UserStatus status = resolveCurrentUserStatus(cached.getUserId());
-                log.info(
-                        "[Auth][TokenReissue] cache_hit userId={} status={}",
-                        cached.getUserId(),
-                        status);
-                return authSessionIssueService.issueTokens(cached.getUserId(), status);
+                log.info("[Auth][TokenReissue] cache_hit userId={}", cached.getUserId());
+                return authSessionIssueService.reissueTokens(tokenHash, cached.getUserId());
             }
         } else {
             meterRegistry
@@ -215,28 +211,9 @@ public class AuthCommandService {
                     .increment();
         }
 
-        refreshTokenCacheService.evict(tokenHash);
-        RefreshToken refreshTokenEntity =
-                refreshTokenRepository
-                        .findByTokenHash(tokenHash)
-                        .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
-
-        if (refreshTokenEntity.getRevokedAt() != null) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
-        }
-
-        if (!refreshTokenEntity.getExpiresAt().isAfter(now)) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
-        }
-
-        User user = refreshTokenEntity.getUser();
-        if (user == null) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
-        }
-
-        refreshTokenEntity.revoke(now);
-        log.info("[Auth][TokenReissue] db_hit userId={} status={}", user.getId(), user.getStatus());
-        return authSessionIssueService.issueTokens(user.getId(), user.getStatus());
+        AuthTokenReissueResult result = authSessionIssueService.reissueTokens(tokenHash);
+        log.info("[Auth][TokenReissue] db_hit tokenHashFingerprint={}", fingerprint(tokenHash));
+        return result;
     }
 
     private GithubAccessTokenResponse exchangeToken(String code) {
@@ -276,13 +253,6 @@ public class AuthCommandService {
             log.warn("[Auth][FetchUser] 사용자 조회 실패: 사유=응답 없음 또는 id 누락, response={}", response);
         }
         return response;
-    }
-
-    private UserStatus resolveCurrentUserStatus(Long userId) {
-        return userRepository
-                .findById(userId)
-                .map(User::getStatus)
-                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
     }
 
     private String normalizeScopes(String scope) {

--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthSessionIssueService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthSessionIssueService.java
@@ -1,9 +1,12 @@
 package com.sipomeokjo.commitme.domain.auth.service;
 
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
 import com.sipomeokjo.commitme.domain.auth.dto.AuthTokenReissueResult;
 import com.sipomeokjo.commitme.domain.refreshToken.entity.RefreshToken;
 import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
-import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheService;
+import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheAfterCommitService;
+import com.sipomeokjo.commitme.domain.user.entity.User;
 import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
 import com.sipomeokjo.commitme.domain.user.repository.UserRepository;
 import com.sipomeokjo.commitme.security.jwt.AccessTokenProvider;
@@ -17,30 +20,74 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class AuthSessionIssueService {
 
     private final RefreshTokenRepository refreshTokenRepository;
-    private final RefreshTokenCacheService refreshTokenCacheService;
+    private final RefreshTokenCacheAfterCommitService refreshTokenCacheAfterCommitService;
     private final UserRepository userRepository;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final JwtProperties jwtProperties;
     private final Clock clock;
 
+    @Transactional
     public AuthTokenReissueResult rotateTokens(Long userId, UserStatus status) {
         Instant now = Instant.now(clock);
         List<String> activeTokenHashes =
                 refreshTokenRepository.findActiveTokenHashesByUserId(userId);
         if (!activeTokenHashes.isEmpty()) {
             refreshTokenRepository.revokeAllByUserId(userId, now);
-            refreshTokenCacheService.evictAll(activeTokenHashes);
+            refreshTokenCacheAfterCommitService.evictAll(activeTokenHashes);
         }
-        return issueTokens(userId, status);
+        return issueTokensInternal(userId, status);
     }
 
+    @Transactional
     public AuthTokenReissueResult issueTokens(Long userId, UserStatus status) {
+        return issueTokensInternal(userId, status);
+    }
+
+    @Transactional
+    public AuthTokenReissueResult reissueTokens(String tokenHash, Long userId) {
+        int revoked = refreshTokenRepository.revokeByTokenHash(tokenHash, Instant.now(clock));
+        if (revoked <= 0) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        refreshTokenCacheAfterCommitService.evict(tokenHash);
+        UserStatus status =
+                userRepository
+                        .findById(userId)
+                        .map(User::getStatus)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
+        return issueTokensInternal(userId, status);
+    }
+
+    @Transactional
+    public AuthTokenReissueResult reissueTokens(String tokenHash) {
+        Instant now = Instant.now(clock);
+        RefreshToken refreshTokenEntity =
+                refreshTokenRepository
+                        .findByTokenHash(tokenHash)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
+
+        if (refreshTokenEntity.getRevokedAt() != null
+                || !refreshTokenEntity.getExpiresAt().isAfter(now)) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        var user = refreshTokenEntity.getUser();
+        if (user == null) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        refreshTokenEntity.revoke(now);
+        refreshTokenCacheAfterCommitService.evict(tokenHash);
+        return issueTokensInternal(user.getId(), user.getStatus());
+    }
+
+    private AuthTokenReissueResult issueTokensInternal(Long userId, UserStatus status) {
         String accessToken = accessTokenProvider.createAccessToken(userId, status);
         String refreshToken = refreshTokenProvider.generateRawToken();
         String refreshTokenHash = refreshTokenProvider.hash(refreshToken);
@@ -54,19 +101,22 @@ public class AuthSessionIssueService {
                         .revokedAt(null)
                         .build();
         refreshTokenRepository.save(refreshTokenEntity);
-        refreshTokenCacheService.cache(refreshTokenHash, userId, status, refreshExpiresAt);
+        refreshTokenCacheAfterCommitService.cache(
+                refreshTokenHash, userId, status, refreshExpiresAt);
 
         return new AuthTokenReissueResult(accessToken, refreshToken);
     }
 
-    public boolean revokeRefreshToken(String rawRefreshToken) {
+    @Transactional
+    public void revokeRefreshToken(String rawRefreshToken) {
         if (rawRefreshToken == null || rawRefreshToken.isBlank()) {
-            return false;
+            return;
         }
 
         String tokenHash = refreshTokenProvider.hash(rawRefreshToken);
         int revoked = refreshTokenRepository.revokeByTokenHash(tokenHash, Instant.now(clock));
-        refreshTokenCacheService.evict(tokenHash);
-        return revoked > 0;
+        if (revoked > 0) {
+            refreshTokenCacheAfterCommitService.evict(tokenHash);
+        }
     }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/refreshToken/service/RefreshTokenCacheAfterCommitService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/refreshToken/service/RefreshTokenCacheAfterCommitService.java
@@ -1,0 +1,49 @@
+package com.sipomeokjo.commitme.domain.refreshToken.service;
+
+import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenCacheAfterCommitService {
+
+    private final RefreshTokenCacheService refreshTokenCacheService;
+
+    public void cache(String tokenHash, Long userId, UserStatus status, Instant expiresAt) {
+        executeAfterCommit(
+                () -> refreshTokenCacheService.cache(tokenHash, userId, status, expiresAt));
+    }
+
+    public void evict(String tokenHash) {
+        executeAfterCommit(() -> refreshTokenCacheService.evict(tokenHash));
+    }
+
+    public void evictAll(Collection<String> tokenHashes) {
+        if (tokenHashes == null || tokenHashes.isEmpty()) {
+            return;
+        }
+        List<String> copiedTokenHashes = List.copyOf(tokenHashes);
+        executeAfterCommit(() -> refreshTokenCacheService.evictAll(copiedTokenHashes));
+    }
+
+    private void executeAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            action.run();
+                        }
+                    });
+            return;
+        }
+        action.run();
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/user/service/UserCommandService.java
@@ -10,7 +10,7 @@ import com.sipomeokjo.commitme.domain.policy.repository.PolicyAgreementRepositor
 import com.sipomeokjo.commitme.domain.position.entity.Position;
 import com.sipomeokjo.commitme.domain.position.service.PositionFinder;
 import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
-import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheService;
+import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheAfterCommitService;
 import com.sipomeokjo.commitme.domain.upload.service.S3UploadService;
 import com.sipomeokjo.commitme.domain.user.dto.OnboardingRequest;
 import com.sipomeokjo.commitme.domain.user.dto.OnboardingResponse;
@@ -39,7 +39,7 @@ public class UserCommandService {
     private final Clock clock;
     private final AuthRepository authRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final RefreshTokenCacheService refreshTokenCacheService;
+    private final RefreshTokenCacheAfterCommitService refreshTokenCacheAfterCommitService;
     private final UserRepository userRepository;
     private final PolicyAgreementRepository policyAgreementRepository;
     private final S3UploadService s3UploadService;
@@ -103,7 +103,7 @@ public class UserCommandService {
         user.deactivate(Instant.now(clock));
         refreshTokenRepository.revokeAllByUserId(userId, Instant.now(clock));
         if (!activeTokenHashes.isEmpty()) {
-            refreshTokenCacheService.evictAll(activeTokenHashes);
+            refreshTokenCacheAfterCommitService.evictAll(activeTokenHashes);
         }
 
         for (Auth auth : authRepository.findAllByUser_Id(userId)) {

--- a/src/test/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandServiceTest.java
@@ -19,7 +19,6 @@ import com.sipomeokjo.commitme.domain.auth.dto.GithubUserResponse;
 import com.sipomeokjo.commitme.domain.auth.entity.Auth;
 import com.sipomeokjo.commitme.domain.auth.entity.AuthProvider;
 import com.sipomeokjo.commitme.domain.auth.repository.AuthRepository;
-import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
 import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheService;
 import com.sipomeokjo.commitme.domain.user.entity.User;
 import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
@@ -42,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.http.MediaType;
+import org.springframework.transaction.support.TransactionOperations;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClient.RequestBodySpec;
@@ -57,8 +57,8 @@ class AuthCommandServiceTest {
     @Mock private AuthRepository authRepository;
     @Mock private UserRepository userRepository;
     @Mock private UserSettingRepository userSettingRepository;
-    @Mock private RefreshTokenRepository refreshTokenRepository;
     @Mock private RefreshTokenCacheService refreshTokenCacheService;
+    @Mock private TransactionOperations transactionOperations;
     @Mock private AuthSessionIssueService authSessionIssueService;
     @Mock private AccessTokenCipher accessTokenCipher;
     @Mock private RefreshTokenProvider refreshTokenProvider;
@@ -73,19 +73,18 @@ class AuthCommandServiceTest {
     @Mock private ResponseSpec oauthResponseSpec;
     @Mock private ResponseSpec apiResponseSpec;
 
-    private Clock clock;
     private AuthCommandService authCommandService;
 
     @BeforeEach
     void setUp() {
-        clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneOffset.UTC);
+        Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneOffset.UTC);
         authCommandService =
                 new AuthCommandService(
                         authRepository,
                         userRepository,
                         userSettingRepository,
-                        refreshTokenRepository,
                         refreshTokenCacheService,
+                        transactionOperations,
                         authSessionIssueService,
                         accessTokenCipher,
                         refreshTokenProvider,
@@ -99,6 +98,16 @@ class AuthCommandServiceTest {
         given(githubProperties.getClientSecret()).willReturn("client-secret");
         given(githubProperties.getRedirectUri()).willReturn("https://example.com/callback");
         given(accessTokenCipher.encrypt(anyString())).willReturn("enc-token");
+
+        given(transactionOperations.execute(any()))
+                .willAnswer(
+                        invocation ->
+                                invocation
+                                        .<org.springframework.transaction.support
+                                                                .TransactionCallback<
+                                                        AuthLoginResult>>
+                                                getArgument(0)
+                                        .doInTransaction(null));
     }
 
     @Test
@@ -117,7 +126,7 @@ class AuthCommandServiceTest {
                         .user(inactiveUser)
                         .build();
 
-        stubGithubExchangeAndFetch("oauth-access-token", 100L, "octocat");
+        stubGithubExchangeAndFetch(100L, "octocat");
         given(authRepository.findByProviderAndProviderUserIdWithLock(AuthProvider.GITHUB, "100"))
                 .willReturn(Optional.of(auth));
 
@@ -144,7 +153,7 @@ class AuthCommandServiceTest {
                         .user(oldUser)
                         .build();
 
-        stubGithubExchangeAndFetch("oauth-access-token", 200L, "new-name");
+        stubGithubExchangeAndFetch(200L, "new-name");
         given(authRepository.findByProviderAndProviderUserIdWithLock(AuthProvider.GITHUB, "200"))
                 .willReturn(Optional.of(auth));
 
@@ -178,7 +187,7 @@ class AuthCommandServiceTest {
         verify(authSessionIssueService).issueTokens(1001L, UserStatus.PENDING);
     }
 
-    private void stubGithubExchangeAndFetch(String accessToken, Long githubUserId, String login) {
+    private void stubGithubExchangeAndFetch(Long githubUserId, String login) {
         given(githubOAuthClient.post()).willReturn(oauthPostSpec);
         given(oauthPostSpec.uri("/login/oauth/access_token")).willReturn(oauthBodySpec);
         given(oauthBodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED))
@@ -187,11 +196,12 @@ class AuthCommandServiceTest {
         doReturn(oauthBodySpec).when(oauthBodySpec).body(any(MultiValueMap.class));
         given(oauthBodySpec.retrieve()).willReturn(oauthResponseSpec);
         given(oauthResponseSpec.body(GithubAccessTokenResponse.class))
-                .willReturn(new GithubAccessTokenResponse(accessToken, "bearer", "repo user"));
+                .willReturn(
+                        new GithubAccessTokenResponse("oauth-access-token", "bearer", "repo user"));
 
         given(githubApiClient.get()).willReturn(apiGetSpec);
         given(apiGetSpec.uri("/user")).willReturn(apiHeadersSpec);
-        given(apiHeadersSpec.header("Authorization", "Bearer " + accessToken))
+        given(apiHeadersSpec.header("Authorization", "Bearer " + "oauth-access-token"))
                 .willReturn(apiHeadersSpec);
         given(apiHeadersSpec.retrieve()).willReturn(apiResponseSpec);
         given(apiResponseSpec.body(GithubUserResponse.class))

--- a/src/test/java/com/sipomeokjo/commitme/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/user/service/UserCommandServiceTest.java
@@ -10,7 +10,7 @@ import com.sipomeokjo.commitme.domain.policy.entity.PolicyType;
 import com.sipomeokjo.commitme.domain.policy.repository.PolicyAgreementRepository;
 import com.sipomeokjo.commitme.domain.position.service.PositionFinder;
 import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
-import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheService;
+import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheAfterCommitService;
 import com.sipomeokjo.commitme.domain.upload.service.S3UploadService;
 import com.sipomeokjo.commitme.domain.user.dto.UserUpdateRequest;
 import com.sipomeokjo.commitme.domain.user.dto.UserUpdateResponse;
@@ -40,7 +40,7 @@ class UserCommandServiceTest {
     @Mock private S3UploadService s3UploadService;
     @Mock private AuthRepository authRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
-    @Mock private RefreshTokenCacheService refreshTokenCacheService;
+    @Mock private RefreshTokenCacheAfterCommitService refreshTokenCacheAfterCommitService;
 
     private UserCommandService userCommandService;
 
@@ -52,7 +52,7 @@ class UserCommandServiceTest {
                         clock,
                         authRepository,
                         refreshTokenRepository,
-                        refreshTokenCacheService,
+                        refreshTokenCacheAfterCommitService,
                         userRepository,
                         policyAgreementRepository,
                         s3UploadService,


### PR DESCRIPTION
- Redis 작업을 RefreshTokenCacheAfterCommitService로 분리
- AuthCommandService의 트랜잭셔널 메서드에서 Redis 캐시 갱신을 직접 수행하지 않도록 변경
- DB 커밋 이후에만 Redis 작업이 실행되도록 콜백 기반 처리 추가
    - 활성 트랜잭션이 있으면 TransactionSynchronizationManager에 TransactionSynchronization 등록 후 afterCommit에서 콜백 실행
    - 트랜잭션이 없으면 즉시 Redis 작업 실행

### Description

기존 토큰 폐기 후 신규 토큰을 저장하는 메서드 수행 시 동일한 DB 트랜잭션 내에서 수행하던 Redis 캐싱 작업을 트랜잭션 외부로 분리하였습니다.

### Related Issues

- Resolves #219 
- Related to #209 

### Changes Made

1. Redis 작업을 별도 컴포넌트 RefreshTokenCacheAfterCommitService로 분리했습니다.
    - 콜백은 DB 커밋 이후에만 실행되도록 구현 (TransactionSynchronizationManager를 사용하여 현재 활성 트랜잭션이 있는 경우 TransactionSynchronization을 등록하고 afterCommit에서 콜백 실행 /  트랜잭션이 없는 경우 콜백을 즉시 실행하고 반환)
2. AuthCommandService의 트랜잭셔널 메서드에서 Redis 작업이 트랜잭션 시간에 영향을 주지 않도록 콜백 기반으로 실행 시점을 분리했습니다.

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x ] 코드 스타일 가이드라인을 준수했습니다.

### Additional Notes

- Redis 작업이 커밋 이후 실행되므로, 아주 짧은 구간에서 DB 상태와 Redis 캐시가 일시적으로 불일치할 수 있음. 하지만 Refresh Token의 특성 상, 즉시 로그인/재발급 후 Refresh Token을 사용할 일이 드물다고 판단함