### PR TITLE
refactor: Refresh Token Rotation Cache miss 로직 수정 및 트랜잭션 점유 시간 감축

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthCommandService.java
@@ -199,8 +199,13 @@ public class AuthCommandService {
                 meterRegistry
                         .counter("auth_token_reissue_cache_lookup_total", "result", "hit")
                         .increment();
-                log.info("[Auth][TokenReissue] cache_hit userId={}", cached.getUserId());
-                return authSessionIssueService.reissueTokens(tokenHash, cached.getUserId());
+                UserStatus cachedStatus = parseCachedUserStatus(cached.getUserStatus());
+                log.info(
+                        "[Auth][TokenReissue] cache_hit userId={} status={}",
+                        cached.getUserId(),
+                        cachedStatus);
+                return authSessionIssueService.reissueTokens(
+                        tokenHash, cached.getUserId(), cachedStatus);
             }
         } else {
             meterRegistry
@@ -253,6 +258,18 @@ public class AuthCommandService {
             log.warn("[Auth][FetchUser] 사용자 조회 실패: 사유=응답 없음 또는 id 누락, response={}", response);
         }
         return response;
+    }
+
+    private UserStatus parseCachedUserStatus(String cachedUserStatus) {
+        if (cachedUserStatus == null || cachedUserStatus.isBlank()) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
+        try {
+            return UserStatus.valueOf(cachedUserStatus);
+        } catch (IllegalArgumentException ex) {
+            log.warn("[Auth][TokenReissue] invalid_cached_user_status status={}", cachedUserStatus);
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
     }
 
     private String normalizeScopes(String scope) {

--- a/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthSessionIssueService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/auth/service/AuthSessionIssueService.java
@@ -6,7 +6,6 @@ import com.sipomeokjo.commitme.domain.auth.dto.AuthTokenReissueResult;
 import com.sipomeokjo.commitme.domain.refreshToken.entity.RefreshToken;
 import com.sipomeokjo.commitme.domain.refreshToken.repository.RefreshTokenRepository;
 import com.sipomeokjo.commitme.domain.refreshToken.service.RefreshTokenCacheAfterCommitService;
-import com.sipomeokjo.commitme.domain.user.entity.User;
 import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
 import com.sipomeokjo.commitme.domain.user.repository.UserRepository;
 import com.sipomeokjo.commitme.security.jwt.AccessTokenProvider;
@@ -17,7 +16,7 @@ import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionOperations;
 
 @Service
 @RequiredArgsConstructor
@@ -30,93 +29,146 @@ public class AuthSessionIssueService {
     private final RefreshTokenProvider refreshTokenProvider;
     private final JwtProperties jwtProperties;
     private final Clock clock;
+    private final TransactionOperations transactionOperations;
 
-    @Transactional
     public AuthTokenReissueResult rotateTokens(Long userId, UserStatus status) {
-        Instant now = Instant.now(clock);
-        List<String> activeTokenHashes =
-                refreshTokenRepository.findActiveTokenHashesByUserId(userId);
-        if (!activeTokenHashes.isEmpty()) {
-            refreshTokenRepository.revokeAllByUserId(userId, now);
-            refreshTokenCacheAfterCommitService.evictAll(activeTokenHashes);
-        }
-        return issueTokensInternal(userId, status);
+        PreparedTokenIssue preparedTokenIssue = prepareTokenIssue(userId, status);
+        AuthTokenReissueResult result =
+                transactionOperations.execute(
+                        transactionStatus -> {
+                            Instant now = Instant.now(clock);
+                            List<String> activeTokenHashes =
+                                    refreshTokenRepository.findActiveTokenHashesByUserId(userId);
+                            if (!activeTokenHashes.isEmpty()) {
+                                refreshTokenRepository.revokeAllByUserId(userId, now);
+                                refreshTokenCacheAfterCommitService.evictAll(activeTokenHashes);
+                            }
+                            persistIssuedRefreshToken(preparedTokenIssue);
+                            return preparedTokenIssue.toResult();
+                        });
+        return requireResult(result);
     }
 
-    @Transactional
     public AuthTokenReissueResult issueTokens(Long userId, UserStatus status) {
-        return issueTokensInternal(userId, status);
+        PreparedTokenIssue preparedTokenIssue = prepareTokenIssue(userId, status);
+        AuthTokenReissueResult result =
+                transactionOperations.execute(
+                        transactionStatus -> {
+                            persistIssuedRefreshToken(preparedTokenIssue);
+                            return preparedTokenIssue.toResult();
+                        });
+        return requireResult(result);
     }
 
-    @Transactional
-    public AuthTokenReissueResult reissueTokens(String tokenHash, Long userId) {
-        int revoked = refreshTokenRepository.revokeByTokenHash(tokenHash, Instant.now(clock));
-        if (revoked <= 0) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
-        }
+    public AuthTokenReissueResult reissueTokens(String tokenHash, Long userId, UserStatus status) {
+        PreparedTokenIssue preparedTokenIssue = prepareTokenIssue(userId, status);
+        AuthTokenReissueResult result =
+                transactionOperations.execute(
+                        transactionStatus -> {
+                            int revoked =
+                                    refreshTokenRepository.revokeByTokenHash(
+                                            tokenHash, Instant.now(clock));
+                            if (revoked <= 0) {
+                                throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+                            }
 
-        refreshTokenCacheAfterCommitService.evict(tokenHash);
-        UserStatus status =
-                userRepository
-                        .findById(userId)
-                        .map(User::getStatus)
-                        .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
-        return issueTokensInternal(userId, status);
+                            refreshTokenCacheAfterCommitService.evict(tokenHash);
+                            persistIssuedRefreshToken(preparedTokenIssue);
+                            return preparedTokenIssue.toResult();
+                        });
+        return requireResult(result);
     }
 
-    @Transactional
     public AuthTokenReissueResult reissueTokens(String tokenHash) {
         Instant now = Instant.now(clock);
-        RefreshToken refreshTokenEntity =
+        var refreshTokenSource =
                 refreshTokenRepository
-                        .findByTokenHashWithUser(tokenHash)
+                        .findReissueSourceByTokenHash(tokenHash)
                         .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
 
-        if (refreshTokenEntity.getRevokedAt() != null
-                || !refreshTokenEntity.getExpiresAt().isAfter(now)) {
+        if (refreshTokenSource.getRevokedAt() != null
+                || !refreshTokenSource.getExpiresAt().isAfter(now)) {
             throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
         }
 
-        var user = refreshTokenEntity.getUser();
-        if (user == null) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
-        }
+        PreparedTokenIssue preparedTokenIssue =
+                prepareTokenIssue(
+                        refreshTokenSource.getUserId(), refreshTokenSource.getUserStatus());
+        AuthTokenReissueResult result =
+                transactionOperations.execute(
+                        transactionStatus -> {
+                            int revoked =
+                                    refreshTokenRepository.revokeByTokenHash(
+                                            tokenHash, Instant.now(clock));
+                            if (revoked <= 0) {
+                                throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+                            }
 
-        refreshTokenEntity.revoke(now);
-        refreshTokenCacheAfterCommitService.evict(tokenHash);
-        return issueTokensInternal(user.getId(), user.getStatus());
+                            refreshTokenCacheAfterCommitService.evict(tokenHash);
+                            persistIssuedRefreshToken(preparedTokenIssue);
+                            return preparedTokenIssue.toResult();
+                        });
+        return requireResult(result);
     }
 
-    private AuthTokenReissueResult issueTokensInternal(Long userId, UserStatus status) {
-        String accessToken = accessTokenProvider.createAccessToken(userId, status);
-        String refreshToken = refreshTokenProvider.generateRawToken();
-        String refreshTokenHash = refreshTokenProvider.hash(refreshToken);
-
-        Instant refreshExpiresAt = Instant.now(clock).plus(jwtProperties.getRefreshExpiration());
-        RefreshToken refreshTokenEntity =
-                RefreshToken.builder()
-                        .user(userRepository.getReferenceById(userId))
-                        .tokenHash(refreshTokenHash)
-                        .expiresAt(refreshExpiresAt)
-                        .revokedAt(null)
-                        .build();
-        refreshTokenRepository.save(refreshTokenEntity);
-        refreshTokenCacheAfterCommitService.cache(
-                refreshTokenHash, userId, status, refreshExpiresAt);
-
-        return new AuthTokenReissueResult(accessToken, refreshToken);
-    }
-
-    @Transactional
     public void revokeRefreshToken(String rawRefreshToken) {
         if (rawRefreshToken == null || rawRefreshToken.isBlank()) {
             return;
         }
 
         String tokenHash = refreshTokenProvider.hash(rawRefreshToken);
-        int revoked = refreshTokenRepository.revokeByTokenHash(tokenHash, Instant.now(clock));
-        if (revoked > 0) {
-            refreshTokenCacheAfterCommitService.evict(tokenHash);
+        transactionOperations.executeWithoutResult(
+                transactionStatus -> {
+                    int revoked =
+                            refreshTokenRepository.revokeByTokenHash(tokenHash, Instant.now(clock));
+                    if (revoked > 0) {
+                        refreshTokenCacheAfterCommitService.evict(tokenHash);
+                    }
+                });
+    }
+
+    private PreparedTokenIssue prepareTokenIssue(Long userId, UserStatus status) {
+        String accessToken = accessTokenProvider.createAccessToken(userId, status);
+        String refreshToken = refreshTokenProvider.generateRawToken();
+        String refreshTokenHash = refreshTokenProvider.hash(refreshToken);
+        Instant refreshExpiresAt = Instant.now(clock).plus(jwtProperties.getRefreshExpiration());
+        return new PreparedTokenIssue(
+                userId, status, accessToken, refreshToken, refreshTokenHash, refreshExpiresAt);
+    }
+
+    private void persistIssuedRefreshToken(PreparedTokenIssue preparedTokenIssue) {
+        RefreshToken refreshTokenEntity =
+                RefreshToken.builder()
+                        .user(userRepository.getReferenceById(preparedTokenIssue.userId()))
+                        .tokenHash(preparedTokenIssue.refreshTokenHash())
+                        .expiresAt(preparedTokenIssue.refreshExpiresAt())
+                        .revokedAt(null)
+                        .build();
+        refreshTokenRepository.save(refreshTokenEntity);
+        refreshTokenCacheAfterCommitService.cache(
+                preparedTokenIssue.refreshTokenHash(),
+                preparedTokenIssue.userId(),
+                preparedTokenIssue.status(),
+                preparedTokenIssue.refreshExpiresAt());
+    }
+
+    private AuthTokenReissueResult requireResult(AuthTokenReissueResult result) {
+        if (result == null) {
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+        return result;
+    }
+
+    private record PreparedTokenIssue(
+            Long userId,
+            UserStatus status,
+            String accessToken,
+            String refreshToken,
+            String refreshTokenHash,
+            Instant refreshExpiresAt) {
+
+        private AuthTokenReissueResult toResult() {
+            return new AuthTokenReissueResult(accessToken, refreshToken);
         }
     }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/refreshToken/repository/RefreshTokenRepository.java
@@ -1,6 +1,7 @@
 package com.sipomeokjo.commitme.domain.refreshToken.repository;
 
 import com.sipomeokjo.commitme.domain.refreshToken.entity.RefreshToken;
+import com.sipomeokjo.commitme.domain.user.entity.UserStatus;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -12,14 +13,19 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    @Query(
+	
+	@Query(
             """
-            select token
+            select token.user.id as userId,
+                   user.status as userStatus,
+                   token.expiresAt as expiresAt,
+                   token.revokedAt as revokedAt
               from RefreshToken token
-              join fetch token.user user
+              join token.user user
              where token.tokenHash = :tokenHash
             """)
-    Optional<RefreshToken> findByTokenHashWithUser(@Param("tokenHash") String tokenHash);
+    Optional<RefreshTokenReissueSourceView> findReissueSourceByTokenHash(
+            @Param("tokenHash") String tokenHash);
 
     @Query(
             """
@@ -72,4 +78,14 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from RefreshToken token where token.user.id in :userIds")
     int deleteAllByUserIds(@Param("userIds") List<Long> userIds);
+
+    interface RefreshTokenReissueSourceView {
+        Long getUserId();
+
+        UserStatus getUserStatus();
+
+        Instant getExpiresAt();
+
+        Instant getRevokedAt();
+    }
 }


### PR DESCRIPTION
### Description

Refresh Token Rotation 중 DB 커넥션 점유와 DB 조회 로직을 최소화하도록 개선하였습니다.
토큰 생성, 해시 계산, 캐시 갱신과 같은 DB에 의존하지 않는 작업을 트랜잭션 외부로 제거합니다.

### Related Issues

- Related to #221 

### Changes Made

1. users.status 확인을 위해 DB에서 users를 재조회하던 것을 fetch join으로 한 번만 조회하게 변경하였습니다.
2. 토큰 생성, 해시 계산, 캐시 갱신과 같은 DB와 관련 없는 로직은 DB 트랜잭션 점유 중에 진행하지 않도록 변경하였습니다.
    - `TransactionOperations`를 사용하여 람다 블록 내의 코드만 트랜잭션 진행하도록 변경
    - `@Transactional`을 사용하는 메서드로 분리하는 것도 고려해보았으나, self-invocation에 해당하므로 AOP가 미적용될 가능성이 있음. 따라서 어노테이션을 사용하는 메서드로 분리 하고자 한다면 별도 빈으로 분리가 필요함. 하지만 이 방식은 단순 Refresh Token 갱신 트랜잭션을 분리하기 위함이므로, 빈을 분리하는 것은 과하다고 판단함.

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.