### PR TITLE
feat: Aggregation Pipeline 추가

### DIFF
--- a/src/main/java/com/sipomeokjo/commitme/domain/outbox/repository/OutboxEventRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/outbox/repository/OutboxEventRepository.java
@@ -35,5 +35,8 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
     List<OutboxEvent> findStuckProcessingEventsWithLock(
             @Param("lockedBefore") Instant lockedBefore, @Param("limit") int limit);
 
+    boolean existsByEventTypeAndAggregateTypeAndAggregateId(
+            String eventType, String aggregateType, String aggregateId);
+
     void deleteByAggregateId(String aggregateId);
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/document/ResumeDocument.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/document/ResumeDocument.java
@@ -19,6 +19,11 @@ import org.springframework.data.mongodb.core.mapping.Field;
 @CompoundIndexes({
     @CompoundIndex(name = "ux_resumes_resume_id", def = "{'resume_id': 1}", unique = true),
     @CompoundIndex(
+            name = "ux_resumes_user_pending_true",
+            def = "{'user_id': 1, 'has_pending_work': 1}",
+            unique = true,
+            partialFilter = "{'has_pending_work': true}"),
+    @CompoundIndex(
             name = "ix_resumes_user_updated_desc",
             def = "{'user_id': 1, 'updated_at': -1, 'resume_id': -1}"),
     @CompoundIndex(

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventAggregationRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventAggregationRepository.java
@@ -1,0 +1,97 @@
+package com.sipomeokjo.commitme.domain.resume.repository.mongo;
+
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventAggregationResult.VersionListResult;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.bson.Document;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.FacetOperation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Repository;
+
+/**
+ * MongoDB Aggregation Pipeline 기반 이력서 이벤트 복합 조회.
+ *
+ * <p>두 결과가 동일한 outer $match 조건을 공유하는 경우에만 $facet을 적용한다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class ResumeEventAggregationRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * 버전 목록 조회용 aggregation.
+     *
+     * <p>커밋된 SUCCEEDED 이벤트를 커서 기반으로 페이지네이션하고, 첫 페이지에서는 최신 SUCCEEDED 이벤트(미커밋 포함)도 함께 반환한다.
+     *
+     * <p>Pipeline: $match(resume_id, status=SUCCEEDED) → $facet(committedPage, latestSucceeded)
+     *
+     * @param resumeId 이력서 ID
+     * @param cursorVersionNo 커서 버전 번호 (null이면 첫 페이지)
+     * @param pageSize 페이지 크기 (hasMore 판단을 위해 실제로 pageSize+1 조회)
+     */
+    public VersionListResult findVersionListPage(
+            Long resumeId, Integer cursorVersionNo, int pageSize) {
+
+        MatchOperation outerMatch =
+                Aggregation.match(
+                        Criteria.where("resume_id")
+                                .is(resumeId)
+                                .and("status")
+                                .is(ResumeVersionStatus.SUCCEEDED));
+
+        List<AggregationOperation> committedBranch = new ArrayList<>();
+        Criteria committedCriteria = Criteria.where("committed_at").ne(null);
+        if (cursorVersionNo != null) {
+            committedCriteria = committedCriteria.and("version_no").lt(cursorVersionNo);
+        }
+        committedBranch.add(Aggregation.match(committedCriteria));
+        committedBranch.add(Aggregation.sort(Sort.by(Sort.Direction.DESC, "version_no")));
+        committedBranch.add(Aggregation.limit(pageSize + 1L));
+
+        List<AggregationOperation> latestBranch =
+                List.of(
+                        Aggregation.sort(Sort.by(Sort.Direction.DESC, "version_no")),
+                        Aggregation.limit(1L));
+
+        FacetOperation facet =
+                Aggregation.facet(committedBranch.toArray(new AggregationOperation[0]))
+                        .as("committedPage")
+                        .and(latestBranch.toArray(new AggregationOperation[0]))
+                        .as("latestSucceeded");
+
+        Aggregation agg = Aggregation.newAggregation(ResumeEventDocument.class, outerMatch, facet);
+        AggregationResults<Document> results =
+                mongoTemplate.aggregate(agg, ResumeEventDocument.class, Document.class);
+
+        Document output = results.getUniqueMappedResult();
+        if (output == null) {
+            return new VersionListResult(List.of(), null);
+        }
+
+        MongoConverter converter = mongoTemplate.getConverter();
+
+        List<ResumeEventDocument> committedPage =
+                output.getList("committedPage", Document.class).stream()
+                        .map(d -> converter.read(ResumeEventDocument.class, d))
+                        .toList();
+
+        List<Document> latestDocs = output.getList("latestSucceeded", Document.class);
+        ResumeEventDocument latestSucceeded =
+                latestDocs.isEmpty()
+                        ? null
+                        : converter.read(ResumeEventDocument.class, latestDocs.getFirst());
+
+        return new VersionListResult(committedPage, latestSucceeded);
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventAggregationResult.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventAggregationResult.java
@@ -1,0 +1,12 @@
+package com.sipomeokjo.commitme.domain.resume.repository.mongo;
+
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import java.util.List;
+
+public final class ResumeEventAggregationResult {
+
+    private ResumeEventAggregationResult() {}
+
+    public record VersionListResult(
+            List<ResumeEventDocument> committedPage, ResumeEventDocument latestSucceeded) {}
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventMongoRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventMongoRepository.java
@@ -2,6 +2,7 @@ package com.sipomeokjo.commitme.domain.resume.repository.mongo;
 
 import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
 import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -35,19 +36,12 @@ public interface ResumeEventMongoRepository extends MongoRepository<ResumeEventD
 
     List<ResumeEventDocument> findByStatusIn(List<ResumeVersionStatus> statuses);
 
+    List<ResumeEventDocument> findByVersionNoAndStatusAndAiTaskIdIsNullAndCreatedAtBefore(
+            Integer versionNo, ResumeVersionStatus status, Instant createdAtBefore);
+
     long countByResumeIdIn(List<Long> resumeIds);
 
     void deleteByResumeId(Long resumeId);
 
     void deleteByResumeIdIn(List<Long> resumeIds);
-
-    List<ResumeEventDocument> findByResumeIdAndStatusAndCommittedAtIsNotNullOrderByVersionNoDesc(
-            Long resumeId, ResumeVersionStatus status, Pageable pageable);
-
-    List<ResumeEventDocument>
-            findByResumeIdAndStatusAndCommittedAtIsNotNullAndVersionNoLessThanOrderByVersionNoDesc(
-                    Long resumeId,
-                    ResumeVersionStatus status,
-                    Integer versionNo,
-                    Pageable pageable);
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventQueryRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeEventQueryRepository.java
@@ -47,4 +47,34 @@ public class ResumeEventQueryRepository {
                         ResumeEventDocument.class);
         return Optional.ofNullable(result);
     }
+
+    public Optional<ResumeEventDocument> bindAiTaskIdAndStartProcessing(
+            Long resumeId, Integer versionNo, String aiTaskId, Instant startedAt) {
+        Criteria criteria =
+                Criteria.where("resume_id")
+                        .is(resumeId)
+                        .and("version_no")
+                        .is(versionNo)
+                        .and("status")
+                        .is(ResumeVersionStatus.QUEUED)
+                        .and("ai_task_id")
+                        .is(null);
+
+        Update update =
+                new Update()
+                        .set("ai_task_id", aiTaskId)
+                        .set("status", ResumeVersionStatus.PROCESSING)
+                        .set("started_at", startedAt)
+                        .set("finished_at", null)
+                        .set("error_log", null)
+                        .set("updated_at", startedAt);
+
+        ResumeEventDocument result =
+                mongoTemplate.findAndModify(
+                        Query.query(criteria),
+                        update,
+                        FindAndModifyOptions.options().returnNew(true),
+                        ResumeEventDocument.class);
+        return Optional.ofNullable(result);
+    }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeMongoQueryRepository.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/repository/mongo/ResumeMongoQueryRepository.java
@@ -65,13 +65,15 @@ public class ResumeMongoQueryRepository {
         return mongoTemplate.find(query, ResumeDocument.class);
     }
 
-    public void clearUnseenPreviewIfPresent(Long resumeId) {
+    public void clearUnseenPreviewIfLatestVersion(Long resumeId, Integer latestPreviewVersionNo) {
         Query query =
                 Query.query(
                         Criteria.where("resume_id")
                                 .is(resumeId)
                                 .and("has_unseen_preview")
-                                .is(true));
+                                .is(true)
+                                .and("latest_preview_version_no")
+                                .is(latestPreviewVersionNo));
         Update update = Update.update("has_unseen_preview", false);
         mongoTemplate.findAndModify(
                 query,

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeCreateRepairService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeCreateRepairService.java
@@ -1,0 +1,61 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import com.sipomeokjo.commitme.domain.outbox.dto.OutboxEventTypes;
+import com.sipomeokjo.commitme.domain.outbox.repository.OutboxEventRepository;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ResumeCreateRepairService {
+    private static final String RESUME_EVENT_AGGREGATE_TYPE = "RESUME_EVENT";
+
+    private final ResumeEventMongoRepository resumeEventMongoRepository;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ResumeProjectionService resumeProjectionService;
+    private final Clock clock;
+
+    @Value("${app.resume.create-repair-grace-minutes:2}")
+    private long repairGraceMinutes;
+
+    @Scheduled(fixedDelayString = "${app.resume.create-repair-delay-ms:60000}")
+    public void repairQueuedCreatesMissingOutbox() {
+        Instant cutoff = Instant.now(clock).minus(repairGraceMinutes, ChronoUnit.MINUTES);
+
+        List<ResumeEventDocument> orphanCandidates =
+                resumeEventMongoRepository
+                        .findByVersionNoAndStatusAndAiTaskIdIsNullAndCreatedAtBefore(
+                                1, ResumeVersionStatus.QUEUED, cutoff);
+
+        int repairedCount = 0;
+        for (ResumeEventDocument event : orphanCandidates) {
+            boolean hasOutbox =
+                    outboxEventRepository.existsByEventTypeAndAggregateTypeAndAggregateId(
+                            OutboxEventTypes.AI_JOB_REQUESTED,
+                            RESUME_EVENT_AGGREGATE_TYPE,
+                            String.valueOf(event.getResumeId()));
+            if (hasOutbox) {
+                continue;
+            }
+            event.failNow("OUTBOX_MISSING", "AI 요청 outbox 이벤트를 찾을 수 없습니다.");
+            resumeEventMongoRepository.save(event);
+            resumeProjectionService.applyAiFailure(event.getResumeId(), event.getVersionNo());
+            repairedCount++;
+        }
+
+        if (repairedCount > 0) {
+            log.warn("[RESUME_CREATE_REPAIR] repaired_missing_outbox count={}", repairedCount);
+        }
+    }
+}

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeDiffService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeDiffService.java
@@ -40,13 +40,7 @@ public class ResumeDiffService {
                         .findByResumeIdAndVersionNo(resumeId, targetVersionNo)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
-        if (targetEvent.getStatus() != ResumeVersionStatus.SUCCEEDED
-                || targetEvent.getCommittedAt() == null) {
-            throw new BusinessException(ErrorCode.RESUME_VERSION_NOT_READY);
-        }
-
-        Map<String, Object> targetSnapshot =
-                parseSnapshot(targetEvent.getSnapshot(), resumeId, targetVersionNo);
+        validateCommittedSucceeded(targetEvent);
 
         if (baseVersionNo == targetVersionNo) {
             return new ResumeVersionDiffDto(resumeId, baseVersionNo, targetVersionNo, List.of());
@@ -57,11 +51,10 @@ public class ResumeDiffService {
                         .findByResumeIdAndVersionNo(resumeId, baseVersionNo)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
-        if (baseEvent.getStatus() != ResumeVersionStatus.SUCCEEDED
-                || baseEvent.getCommittedAt() == null) {
-            throw new BusinessException(ErrorCode.RESUME_VERSION_NOT_READY);
-        }
+        validateCommittedSucceeded(baseEvent);
 
+        Map<String, Object> targetSnapshot =
+                parseSnapshot(targetEvent.getSnapshot(), resumeId, targetVersionNo);
         Map<String, Object> baseSnapshot =
                 parseSnapshot(baseEvent.getSnapshot(), resumeId, baseVersionNo);
 
@@ -79,6 +72,12 @@ public class ResumeDiffService {
                         .toList();
 
         return new ResumeVersionDiffDto(resumeId, baseVersionNo, targetVersionNo, diffs);
+    }
+
+    private void validateCommittedSucceeded(ResumeEventDocument event) {
+        if (event.getStatus() != ResumeVersionStatus.SUCCEEDED || event.getCommittedAt() == null) {
+            throw new BusinessException(ErrorCode.RESUME_VERSION_NOT_READY);
+        }
     }
 
     private int resolveBaseVersionNo(Long userId, Long resumeId, String baseParam) {
@@ -118,7 +117,7 @@ public class ResumeDiffService {
                     resumeId,
                     versionNo,
                     e.getMessage());
-            return Map.of();
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeEditTransactionService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeEditTransactionService.java
@@ -6,6 +6,7 @@ import com.sipomeokjo.commitme.domain.resume.document.ResumeDocument;
 import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
 import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventQueryRepository;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ResumeEditTransactionService {
     private final ResumeEventMongoRepository resumeEventMongoRepository;
+    private final ResumeEventQueryRepository resumeEventQueryRepository;
     private final ResumeProjectionService resumeProjectionService;
 
-    @Transactional
+    @Transactional("mongoTransactionManager")
     public EditPrepared prepareEdit(Long userId, Long resumeId) {
         ResumeDocument doc = resumeProjectionService.markPendingIfIdleOrThrow(resumeId, userId);
 
@@ -60,16 +62,15 @@ public class ResumeEditTransactionService {
 
     @Transactional("mongoTransactionManager")
     public ResumeEventDocument markEditRequested(Long resumeId, Integer versionNo, String jobId) {
-        ResumeEventDocument event =
-                resumeEventMongoRepository
-                        .findByResumeIdAndVersionNo(resumeId, versionNo)
-                        .orElseThrow(
-                                () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
-        event.startProcessing(jobId, Instant.now());
-        return resumeEventMongoRepository.save(event);
+        return resumeEventQueryRepository
+                .bindAiTaskIdAndStartProcessing(resumeId, versionNo, jobId, Instant.now())
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Failed to bind AI task id to resume edit event"));
     }
 
-    @Transactional
+    @Transactional("mongoTransactionManager")
     public void markEditFailed(Long resumeId, Integer versionNo, String errorMessage) {
         resumeEventMongoRepository
                 .findByResumeIdAndVersionNo(resumeId, versionNo)
@@ -77,6 +78,7 @@ public class ResumeEditTransactionService {
                         event -> {
                             event.failNow("AI_EDIT_FAILED", errorMessage);
                             resumeEventMongoRepository.save(event);
+                            resumeProjectionService.applyAiFailure(resumeId, versionNo);
                         },
                         () ->
                                 log.error(

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeProfileService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeProfileService.java
@@ -117,7 +117,7 @@ public class ResumeProfileService {
     @Transactional
     public ResumeProfileUpdateResponse updateProfile(
             Long userId, Long resumeId, ResumeProfileRequest request) {
-        resumeProjectionService.getByResumeIdAndUserIdOrThrow(resumeId, userId);
+        resumeProjectionService.validateOwnershipOrThrow(resumeId, userId);
         User user = userFinder.getByIdOrThrow(userId);
         validateProfileRequest(request);
         updateUserContact(user, request);

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeProjectionService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeProjectionService.java
@@ -8,9 +8,11 @@ import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoQueryRepository;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoRepository;
+import java.time.Clock;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -30,6 +32,7 @@ public class ResumeProjectionService {
     private final ResumeMongoQueryRepository resumeMongoQueryRepository;
     private final ResumeEventMongoRepository resumeEventMongoRepository;
     private final MongoTemplate mongoTemplate;
+    private final Clock clock;
 
     public void createProjection(ResumeDocument document) {
         resumeMongoRepository.save(document);
@@ -41,21 +44,34 @@ public class ResumeProjectionService {
         if (resumeMongoRepository.existsByUserIdAndHasPendingWorkTrue(userId)) {
             throw new BusinessException(ErrorCode.RESUME_GENERATION_IN_PROGRESS);
         }
-        resumeMongoRepository.save(projection);
-        resumeEventMongoRepository.save(event);
+        try {
+            resumeMongoRepository.save(projection);
+            resumeEventMongoRepository.save(event);
+        } catch (DuplicateKeyException e) {
+            throw translateDuplicateKeyException(e, ErrorCode.RESUME_GENERATION_IN_PROGRESS);
+        }
     }
 
     public ResumeDocument markPendingIfIdleOrThrow(Long resumeId, Long userId) {
-        if (!resumeMongoRepository.existsByResumeIdAndUserId(resumeId, userId)) {
-            throw new BusinessException(ErrorCode.RESUME_NOT_FOUND);
-        }
-
         Criteria criteria =
-                Criteria.where("resume_id").is(resumeId).and("has_pending_work").is(false);
-        Update update = new Update().set("has_pending_work", true).set("updated_at", Instant.now());
-        ResumeDocument prev =
-                mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
+                Criteria.where("resume_id")
+                        .is(resumeId)
+                        .and("user_id")
+                        .is(userId)
+                        .and("has_pending_work")
+                        .is(false);
+        Update update =
+                new Update().set("has_pending_work", true).set("updated_at", Instant.now(clock));
+        ResumeDocument prev;
+        try {
+            prev = mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
+        } catch (DuplicateKeyException e) {
+            throw translateDuplicateKeyException(e, ErrorCode.RESUME_EDIT_IN_PROGRESS);
+        }
         if (prev == null) {
+            if (!resumeMongoRepository.existsByResumeIdAndUserId(resumeId, userId)) {
+                throw new BusinessException(ErrorCode.RESUME_NOT_FOUND);
+            }
             throw new BusinessException(ErrorCode.RESUME_EDIT_IN_PROGRESS);
         }
         return prev;
@@ -72,7 +88,7 @@ public class ResumeProjectionService {
     public void setPendingWorkStarted(Long resumeId) {
         mongoTemplate.updateFirst(
                 Query.query(Criteria.where("resume_id").is(resumeId)),
-                new Update().set("has_pending_work", true).set("updated_at", Instant.now()),
+                new Update().set("has_pending_work", true).set("updated_at", Instant.now(clock)),
                 ResumeDocument.class);
     }
 
@@ -97,7 +113,7 @@ public class ResumeProjectionService {
                         .set("has_unseen_preview", true)
                         .set("has_pending_work", false)
                         .set("last_applied_version_no", versionNo)
-                        .set("updated_at", Instant.now());
+                        .set("updated_at", Instant.now(clock));
         if (isCreate) {
             update.set("current_version_no", versionNo);
         }
@@ -122,7 +138,7 @@ public class ResumeProjectionService {
                 new Update()
                         .set("has_pending_work", false)
                         .set("last_applied_version_no", versionNo)
-                        .set("updated_at", Instant.now());
+                        .set("updated_at", Instant.now(clock));
         mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
     }
 
@@ -136,7 +152,7 @@ public class ResumeProjectionService {
                 new Update()
                         .set("current_version_no", versionNo)
                         .max("last_applied_version_no", versionNo)
-                        .set("updated_at", Instant.now());
+                        .set("updated_at", Instant.now(clock));
         mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
     }
 
@@ -167,7 +183,9 @@ public class ResumeProjectionService {
         try {
             mongoTemplate.updateFirst(
                     Query.query(Criteria.where("resume_id").is(resumeId)),
-                    new Update().set("has_pending_work", false).set("updated_at", Instant.now()),
+                    new Update()
+                            .set("has_pending_work", false)
+                            .set("updated_at", Instant.now(clock)),
                     ResumeDocument.class);
             log.warn(
                     "[PROJECTION] hasPendingWork_cleared resumeId={} — rebuildForResume recommended",
@@ -190,7 +208,25 @@ public class ResumeProjectionService {
     }
 
     public void applyPreviewShown(Long resumeId) {
-        resumeMongoQueryRepository.clearUnseenPreviewIfPresent(resumeId);
+        ResumeDocument projection = getByResumeIdOrThrow(resumeId);
+        Integer latestPreviewVersionNo = projection.getLatestPreviewVersionNo();
+        if (latestPreviewVersionNo != null) {
+            resumeMongoQueryRepository.clearUnseenPreviewIfLatestVersion(
+                    resumeId, latestPreviewVersionNo);
+        }
+    }
+
+    @Transactional("mongoTransactionManager")
+    public void markPreviewShownAndClearUnseen(
+            Long resumeId, Integer versionNo, Instant previewShownAt) {
+        ResumeEventDocument event =
+                resumeEventMongoRepository
+                        .findByResumeIdAndVersionNo(resumeId, versionNo)
+                        .orElseThrow(
+                                () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
+        event.markPreviewShown(previewShownAt);
+        resumeEventMongoRepository.save(event);
+        resumeMongoQueryRepository.clearUnseenPreviewIfLatestVersion(resumeId, versionNo);
     }
 
     @Retryable(
@@ -199,7 +235,8 @@ public class ResumeProjectionService {
             backoff = @Backoff(delay = 100, multiplier = 2.0, random = true))
     public void applyProfileSnapshotUpdate(Long resumeId, String json) {
         Criteria criteria = Criteria.where("resume_id").is(resumeId);
-        Update update = new Update().set("profile_snapshot", json).set("updated_at", Instant.now());
+        Update update =
+                new Update().set("profile_snapshot", json).set("updated_at", Instant.now(clock));
         mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
     }
 
@@ -209,8 +246,45 @@ public class ResumeProjectionService {
             backoff = @Backoff(delay = 100, multiplier = 2.0, random = true))
     public void applyNameChange(Long resumeId, String name) {
         Criteria criteria = Criteria.where("resume_id").is(resumeId);
-        Update update = new Update().set("name", name).set("updated_at", Instant.now());
+        Update update = new Update().set("name", name).set("updated_at", Instant.now(clock));
         mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
+    }
+
+    @Transactional("mongoTransactionManager")
+    public void commitVersionAndApplyProjection(
+            Long resumeId, Integer versionNo, Instant committedAt) {
+        ResumeEventDocument event =
+                resumeEventMongoRepository
+                        .findByResumeIdAndVersionNo(resumeId, versionNo)
+                        .orElseThrow(
+                                () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
+        ResumeDocument projection =
+                resumeMongoRepository
+                        .findByResumeId(resumeId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.RESUME_NOT_FOUND));
+
+        boolean isLatestPreviewVersion =
+                projection.getLatestPreviewVersionNo() != null
+                        && projection.getLatestPreviewVersionNo().equals(versionNo);
+        if (event.getCommittedAt() != null) {
+            return;
+        }
+        if (isLatestPreviewVersion) {
+            event.markPreviewShown(committedAt);
+        }
+        event.markCommitted(committedAt);
+        resumeEventMongoRepository.save(event);
+
+        Criteria criteria = Criteria.where("resume_id").is(resumeId);
+        Update update =
+                new Update()
+                        .set("current_version_no", versionNo)
+                        .max("last_applied_version_no", versionNo)
+                        .set("updated_at", Instant.now(clock));
+        mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
+        if (isLatestPreviewVersion) {
+            resumeMongoQueryRepository.clearUnseenPreviewIfLatestVersion(resumeId, versionNo);
+        }
     }
 
     @Transactional("mongoTransactionManager")
@@ -225,7 +299,50 @@ public class ResumeProjectionService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESUME_NOT_FOUND));
     }
 
-    public void getByResumeIdAndUserIdOrThrow(Long resumeId, Long userId) {
+    public void validateOwnershipOrThrow(Long resumeId, Long userId) {
         findDocumentByResumeIdAndUserIdOrThrow(resumeId, userId);
+    }
+
+    @Transactional("mongoTransactionManager")
+    public void applyCreateCompensation(Long resumeId, int versionNo, String errorMessage) {
+        resumeEventMongoRepository
+                .findByResumeIdAndVersionNo(resumeId, versionNo)
+                .ifPresent(
+                        event -> {
+                            event.failNow("OUTBOX_ENQUEUE_FAILED", errorMessage);
+                            resumeEventMongoRepository.save(event);
+                        });
+        Criteria criteria =
+                Criteria.where("resume_id")
+                        .is(resumeId)
+                        .andOperator(
+                                new Criteria()
+                                        .orOperator(
+                                                Criteria.where("last_applied_version_no").isNull(),
+                                                Criteria.where("last_applied_version_no")
+                                                        .lt(versionNo)));
+        Update update =
+                new Update()
+                        .set("has_pending_work", false)
+                        .set("last_applied_version_no", versionNo)
+                        .set("updated_at", Instant.now(clock));
+        mongoTemplate.findAndModify(Query.query(criteria), update, ResumeDocument.class);
+    }
+
+    private BusinessException translateDuplicateKeyException(
+            DuplicateKeyException e, ErrorCode expectedConflictCode) {
+        if (isPendingUniqueViolation(e)) {
+            return new BusinessException(expectedConflictCode);
+        }
+        log.error("[PROJECTION] unexpected_duplicate_key", e);
+        return new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private boolean isPendingUniqueViolation(DuplicateKeyException e) {
+        String message = e.getMessage();
+        return message != null
+                && (message.contains("ux_resumes_user_pending_true")
+                        || message.contains("pending unique")
+                        || message.contains("has_pending_work"));
     }
 }

--- a/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/sipomeokjo/commitme/domain/resume/service/ResumeService.java
@@ -28,6 +28,8 @@ import com.sipomeokjo.commitme.domain.resume.dto.ResumeVersionSummaryDto;
 import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
 import com.sipomeokjo.commitme.domain.resume.event.ResumeGenerateOutboxPayload;
 import com.sipomeokjo.commitme.domain.resume.mapper.ResumeMapper;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventAggregationRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventAggregationResult;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoQueryRepository;
 import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoRepository;
@@ -39,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,9 +50,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @Slf4j
 public class ResumeService {
+    private static final String RESUME_EVENT_AGGREGATE_TYPE = "RESUME_EVENT";
+
     private final ResumeMongoRepository resumeMongoRepository;
     private final ResumeMongoQueryRepository resumeMongoQueryRepository;
     private final ResumeEventMongoRepository resumeEventMongoRepository;
+    private final ResumeEventAggregationRepository resumeEventAggregationRepository;
     private final ResumeFinder resumeFinder;
     private final MongoSequenceService mongoSequenceService;
     private final PositionFinder positionFinder;
@@ -124,7 +128,8 @@ public class ResumeService {
         }
 
         String name = (req.getName() == null) ? "" : req.getName().trim();
-        if (name.isEmpty()) {
+        boolean isUserProvidedName = !name.isEmpty();
+        if (!isUserProvidedName) {
             LocalDateTime now = LocalDateTime.now(clock);
             String base =
                     String.format(
@@ -137,7 +142,9 @@ public class ResumeService {
                             position.getName());
             name = (company != null) ? base + "_" + company.getName() : base;
         }
-        if (name.length() > 30) throw new BusinessException(ErrorCode.INVALID_RESUME_NAME);
+        if (isUserProvidedName && name.length() > 30)
+            throw new BusinessException(ErrorCode.INVALID_RESUME_NAME);
+        if (name.length() > 30) name = name.substring(0, 30);
 
         Long resumeId = mongoSequenceService.nextResumeId();
 
@@ -157,23 +164,32 @@ public class ResumeService {
 
         resumeProjectionService.createProjectionIfNoPendingOrThrow(userId, projection, event);
 
-        outboxEventService.enqueue(
-                OutboxEventTypes.AI_JOB_REQUESTED,
-                "RESUME_EVENT",
-                String.valueOf(resumeId),
-                new ResumeGenerateOutboxPayload(
-                        resumeId, 1, userId, position.getName(), req.getRepoUrls()));
+        try {
+            outboxEventService.enqueue(
+                    OutboxEventTypes.AI_JOB_REQUESTED,
+                    RESUME_EVENT_AGGREGATE_TYPE,
+                    String.valueOf(resumeId),
+                    new ResumeGenerateOutboxPayload(
+                            resumeId, 1, userId, position.getName(), req.getRepoUrls()));
+        } catch (BusinessException e) {
+            compensateCreateFailure(resumeId, e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            compensateCreateFailure(resumeId, e.getMessage());
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
 
         return resumeId;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ResumeDetailDto get(Long userId, Long resumeId) {
 
         ResumeDocument doc = resumeFinder.getDocumentByResumeIdAndUserIdOrThrow(resumeId, userId);
         ResumeProfileResponse profileResponse =
                 resumeProfileService.getProfile(
                         userId, doc.getResumeId(), doc.getProfileSnapshot());
+
         boolean isEditing =
                 resumeEventMongoRepository.existsByResumeIdAndStatusIn(
                         doc.getResumeId(),
@@ -187,9 +203,18 @@ public class ResumeService {
                         .orElse(null);
 
         if (previewEvent != null) {
-            previewEvent.markPreviewShown(Instant.now());
-            resumeEventMongoRepository.save(previewEvent);
-            resumeProjectionService.applyPreviewShown(doc.getResumeId());
+            Instant previewShownAt = Instant.now();
+            try {
+                resumeProjectionService.markPreviewShownAndClearUnseen(
+                        doc.getResumeId(), previewEvent.getVersionNo(), previewShownAt);
+            } catch (Exception e) {
+                log.warn(
+                        "[RESUME_GET] preview_mark_failed resumeId={} versionNo={} — will retry on next GET",
+                        doc.getResumeId(),
+                        previewEvent.getVersionNo(),
+                        e);
+            }
+            previewEvent.markPreviewShown(previewShownAt);
             return resumeMapper.toDetailDtoFromDocument(
                     doc, previewEvent, isEditing, profileResponse);
         }
@@ -199,7 +224,6 @@ public class ResumeService {
                         .findByResumeIdAndVersionNo(doc.getResumeId(), doc.getCurrentVersionNo())
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
-
         if (event.getStatus() != ResumeVersionStatus.SUCCEEDED) {
             throw new BusinessException(ErrorCode.RESUME_VERSION_NOT_READY);
         }
@@ -211,41 +235,25 @@ public class ResumeService {
     public CursorResponse<ResumeVersionSummaryDto> getVersionList(
             Long userId, Long resumeId, CursorRequest request) {
 
-        resumeProjectionService.getByResumeIdAndUserIdOrThrow(resumeId, userId);
+        resumeProjectionService.validateOwnershipOrThrow(resumeId, userId);
 
         int size = CursorRequest.resolveLimit(request, 50);
-
-        Integer cursorVersionNo = null;
-        if (request != null && request.next() != null) {
-            try {
-                cursorVersionNo = Integer.parseInt(request.next());
-            } catch (NumberFormatException e) {
-                throw new BusinessException(ErrorCode.BAD_REQUEST);
-            }
-        }
-
+        Integer cursorVersionNo = parseCursorVersionNo(request);
         boolean isFirstPage = (cursorVersionNo == null);
 
-        List<ResumeEventDocument> events;
-        if (isFirstPage) {
-            events =
-                    resumeEventMongoRepository
-                            .findByResumeIdAndStatusAndCommittedAtIsNotNullOrderByVersionNoDesc(
-                                    resumeId,
-                                    ResumeVersionStatus.SUCCEEDED,
-                                    PageRequest.of(0, size + 1));
-        } else {
-            events =
-                    resumeEventMongoRepository
-                            .findByResumeIdAndStatusAndCommittedAtIsNotNullAndVersionNoLessThanOrderByVersionNoDesc(
-                                    resumeId,
-                                    ResumeVersionStatus.SUCCEEDED,
-                                    cursorVersionNo,
-                                    PageRequest.of(0, size + 1));
-        }
+        ResumeEventAggregationResult.VersionListResult result =
+                resumeEventAggregationRepository.findVersionListPage(
+                        resumeId, cursorVersionNo, size);
 
-        boolean hasMore = events.size() > size;
-        List<ResumeEventDocument> page = hasMore ? events.subList(0, size) : events;
+        boolean includePreview =
+                isFirstPage
+                        && result.latestSucceeded() != null
+                        && result.latestSucceeded().getCommittedAt() == null;
+        int committedLimit = includePreview ? Math.max(size - 1, 0) : size;
+
+        List<ResumeEventDocument> events = result.committedPage();
+        boolean hasMore = events.size() > committedLimit;
+        List<ResumeEventDocument> page = events.subList(0, Math.min(events.size(), committedLimit));
 
         List<ResumeVersionSummaryDto> items =
                 new ArrayList<>(
@@ -256,22 +264,29 @@ public class ResumeService {
                                                         e.getVersionNo(), e.getCommittedAt()))
                                 .toList());
 
-        if (isFirstPage) {
-            resumeEventMongoRepository
-                    .findFirstByResumeIdAndStatusOrderByVersionNoDesc(
-                            resumeId, ResumeVersionStatus.SUCCEEDED)
-                    .ifPresent(
-                            e -> {
-                                if (e.getCommittedAt() == null) {
-                                    items.addFirst(
-                                            new ResumeVersionSummaryDto(e.getVersionNo(), null));
-                                }
-                            });
+        if (includePreview) {
+            items.addFirst(
+                    new ResumeVersionSummaryDto(result.latestSucceeded().getVersionNo(), null));
         }
 
-        String next =
-                hasMore && !page.isEmpty() ? String.valueOf(page.getLast().getVersionNo()) : null;
+        String next = hasMore ? resolveNextVersionCursor(page, events) : null;
         return new CursorResponse<>(items, null, next);
+    }
+
+    private String resolveNextVersionCursor(
+            List<ResumeEventDocument> page, List<ResumeEventDocument> events) {
+        ResumeEventDocument nextCursorSource =
+                !page.isEmpty() ? page.getLast() : (events.isEmpty() ? null : events.getFirst());
+        return nextCursorSource == null ? null : String.valueOf(nextCursorSource.getVersionNo());
+    }
+
+    private Integer parseCursorVersionNo(CursorRequest request) {
+        if (request == null || request.next() == null) return null;
+        try {
+            return Integer.parseInt(request.next());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -289,11 +304,6 @@ public class ResumeService {
                         .findByResumeIdAndVersionNo(doc.getResumeId(), versionNo)
                         .orElseThrow(
                                 () -> new BusinessException(ErrorCode.RESUME_VERSION_NOT_FOUND));
-
-        if (event.isProcessingTimedOut(ResumeVersionTimeoutService.AI_PROCESSING_TIMEOUT_MINUTES)) {
-            event.failNow("TIMEOUT", "AI 서버 응답 시간 초과");
-            resumeEventMongoRepository.save(event);
-        }
 
         return new ResumeVersionDto(
                 doc.getResumeId(),
@@ -315,7 +325,7 @@ public class ResumeService {
         if (name.isEmpty() || name.length() > 30)
             throw new BusinessException(ErrorCode.INVALID_RESUME_NAME);
 
-        resumeProjectionService.getByResumeIdAndUserIdOrThrow(resumeId, userId);
+        resumeProjectionService.validateOwnershipOrThrow(resumeId, userId);
         resumeProjectionService.applyNameChange(resumeId, name);
     }
 
@@ -329,10 +339,27 @@ public class ResumeService {
         ResumeEditTransactionService.EditPrepared prepared =
                 resumeEditTransactionService.prepareEdit(userId, resumeId);
 
+        String jobId;
         try {
-            String jobId =
+            jobId =
                     resumeAiRequestService.requestEdit(
                             prepared.resumeId(), prepared.baseContent(), message);
+        } catch (BusinessException e) {
+            markEditFailedAndLog(userId, resumeId, prepared, e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            markEditFailedAndLog(userId, resumeId, prepared, e.getMessage());
+            throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+        return markEditRequestedAndBuildResponse(userId, resumeId, prepared, jobId);
+    }
+
+    private ResumeEditResponse markEditRequestedAndBuildResponse(
+            Long userId,
+            Long resumeId,
+            ResumeEditTransactionService.EditPrepared prepared,
+            String jobId) {
+        try {
             ResumeEventDocument updated =
                     resumeEditTransactionService.markEditRequested(
                             prepared.resumeId(), prepared.versionNo(), jobId);
@@ -349,10 +376,10 @@ public class ResumeService {
                     updated.getAiTaskId(),
                     updated.getUpdatedAt());
         } catch (BusinessException e) {
-            markEditFailedAndLog(userId, resumeId, prepared, e.getMessage());
+            logEditRequestPersistenceFailure(userId, resumeId, prepared.versionNo(), jobId, e);
             throw e;
         } catch (Exception e) {
-            markEditFailedAndLog(userId, resumeId, prepared, e.getMessage());
+            logEditRequestPersistenceFailure(userId, resumeId, prepared.versionNo(), jobId, e);
             throw new BusinessException(ErrorCode.SERVICE_UNAVAILABLE);
         }
     }
@@ -372,10 +399,22 @@ public class ResumeService {
                 errorMessage);
     }
 
+    private void logEditRequestPersistenceFailure(
+            Long userId, Long resumeId, Integer versionNo, String jobId, Exception exception) {
+        log.error(
+                "[RESUME_EDIT] ai_requested_but_mark_processing_failed userId={} resumeId={} versionNo={} taskId={} error={}",
+                userId,
+                resumeId,
+                versionNo,
+                jobId,
+                exception.getMessage(),
+                exception);
+    }
+
     @Transactional
     public void saveVersion(Long userId, Long resumeId, int versionNo) {
 
-        resumeProjectionService.getByResumeIdAndUserIdOrThrow(resumeId, userId);
+        resumeProjectionService.validateOwnershipOrThrow(resumeId, userId);
 
         ResumeEventDocument event =
                 resumeEventMongoRepository
@@ -386,18 +425,31 @@ public class ResumeService {
         if (event.getStatus() != ResumeVersionStatus.SUCCEEDED) {
             throw new BusinessException(ErrorCode.RESUME_VERSION_NOT_READY);
         }
+        if (event.getCommittedAt() != null) {
+            return;
+        }
 
-        event.markCommitted(Instant.now());
-        resumeEventMongoRepository.save(event);
-        resumeProjectionService.applyVersionCommitted(resumeId, versionNo);
+        resumeProjectionService.commitVersionAndApplyProjection(resumeId, versionNo, Instant.now());
     }
 
     @Transactional
     public void delete(Long userId, Long resumeId) {
-        resumeProjectionService.getByResumeIdAndUserIdOrThrow(resumeId, userId);
+        resumeProjectionService.validateOwnershipOrThrow(resumeId, userId);
 
         outboxEventRepository.deleteByAggregateId(String.valueOf(resumeId));
 
         resumeProjectionService.deleteProjectionAndEvents(resumeId);
+    }
+
+    private void compensateCreateFailure(Long resumeId, String errorMessage) {
+        try {
+            resumeProjectionService.applyCreateCompensation(resumeId, 1, errorMessage);
+        } catch (Exception ex) {
+            log.error(
+                    "[RESUME_CREATE] compensation_failed resumeId={} error={}",
+                    resumeId,
+                    ex.getMessage(),
+                    ex);
+        }
     }
 }

--- a/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeCreateRepairServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeCreateRepairServiceTest.java
@@ -1,0 +1,86 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.sipomeokjo.commitme.domain.outbox.dto.OutboxEventTypes;
+import com.sipomeokjo.commitme.domain.outbox.repository.OutboxEventRepository;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeCreateRepairServiceTest {
+
+    @Mock private ResumeEventMongoRepository resumeEventMongoRepository;
+    @Mock private OutboxEventRepository outboxEventRepository;
+    @Mock private ResumeProjectionService resumeProjectionService;
+
+    private ResumeCreateRepairService resumeCreateRepairService;
+
+    @BeforeEach
+    void setUp() {
+        resumeCreateRepairService =
+                new ResumeCreateRepairService(
+                        resumeEventMongoRepository,
+                        outboxEventRepository,
+                        resumeProjectionService,
+                        Clock.fixed(Instant.parse("2026-03-29T00:10:00Z"), ZoneOffset.UTC));
+        ReflectionTestUtils.setField(resumeCreateRepairService, "repairGraceMinutes", 2L);
+    }
+
+    @Test
+    void repairQueuedCreatesMissingOutbox_marksEventFailedAndClearsPending() {
+        ResumeEventDocument event =
+                ResumeEventDocument.create(100L, 1, 1L, ResumeVersionStatus.QUEUED, "{}");
+        given(
+                        resumeEventMongoRepository
+                                .findByVersionNoAndStatusAndAiTaskIdIsNullAndCreatedAtBefore(
+                                        1,
+                                        ResumeVersionStatus.QUEUED,
+                                        Instant.parse("2026-03-29T00:08:00Z")))
+                .willReturn(List.of(event));
+        given(
+                        outboxEventRepository.existsByEventTypeAndAggregateTypeAndAggregateId(
+                                OutboxEventTypes.AI_JOB_REQUESTED, "RESUME_EVENT", "100"))
+                .willReturn(false);
+
+        resumeCreateRepairService.repairQueuedCreatesMissingOutbox();
+
+        verify(resumeEventMongoRepository).save(event);
+        verify(resumeProjectionService).applyAiFailure(100L, 1);
+    }
+
+    @Test
+    void repairQueuedCreatesMissingOutbox_skipsWhenOutboxExists() {
+        ResumeEventDocument event =
+                ResumeEventDocument.create(100L, 1, 1L, ResumeVersionStatus.QUEUED, "{}");
+        given(
+                        resumeEventMongoRepository
+                                .findByVersionNoAndStatusAndAiTaskIdIsNullAndCreatedAtBefore(
+                                        1,
+                                        ResumeVersionStatus.QUEUED,
+                                        Instant.parse("2026-03-29T00:08:00Z")))
+                .willReturn(List.of(event));
+        given(
+                        outboxEventRepository.existsByEventTypeAndAggregateTypeAndAggregateId(
+                                OutboxEventTypes.AI_JOB_REQUESTED, "RESUME_EVENT", "100"))
+                .willReturn(true);
+
+        resumeCreateRepairService.repairQueuedCreatesMissingOutbox();
+
+        verify(resumeEventMongoRepository, never()).save(event);
+        verify(resumeProjectionService, never()).applyAiFailure(100L, 1);
+    }
+}

--- a/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeDiffServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeDiffServiceTest.java
@@ -1,0 +1,67 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeDocument;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoRepository;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeDiffServiceTest {
+
+    @Mock private ResumeMongoRepository resumeMongoRepository;
+    @Mock private ResumeEventMongoRepository resumeEventMongoRepository;
+
+    private ResumeDiffService resumeDiffService;
+
+    @BeforeEach
+    void setUp() {
+        resumeDiffService =
+                new ResumeDiffService(
+                        resumeMongoRepository, resumeEventMongoRepository, new ObjectMapper());
+    }
+
+    @Test
+    void getDiff_whenSnapshotIsMalformed_throwsInternalServerError() {
+        ResumeDocument document = org.mockito.Mockito.mock(ResumeDocument.class);
+        ResumeEventDocument baseEvent =
+                ResumeEventDocument.create(100L, 1, 1L, ResumeVersionStatus.QUEUED, "{}");
+        ResumeEventDocument targetEvent =
+                ResumeEventDocument.create(100L, 2, 1L, ResumeVersionStatus.QUEUED, "{}");
+        Instant committedAt = Instant.parse("2026-03-29T00:00:00Z");
+
+        baseEvent.succeed("{\"summary\":\"base\"}", committedAt);
+        baseEvent.markCommitted(committedAt);
+        targetEvent.succeed("{", committedAt);
+        targetEvent.markCommitted(committedAt);
+
+        given(resumeMongoRepository.findByResumeId(100L)).willReturn(Optional.of(document));
+        given(document.getUserId()).willReturn(1L);
+        given(document.getCurrentVersionNo()).willReturn(1);
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 2))
+                .willReturn(Optional.of(targetEvent));
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 1))
+                .willReturn(Optional.of(baseEvent));
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class,
+                        () -> resumeDiffService.getDiff(1L, 100L, 2, "current"));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeEditTransactionServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeEditTransactionServiceTest.java
@@ -1,0 +1,75 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventQueryRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeEditTransactionServiceTest {
+
+    @Mock private ResumeEventMongoRepository resumeEventMongoRepository;
+    @Mock private ResumeEventQueryRepository resumeEventQueryRepository;
+    @Mock private ResumeProjectionService resumeProjectionService;
+
+    private ResumeEditTransactionService resumeEditTransactionService;
+
+    @BeforeEach
+    void setUp() {
+        resumeEditTransactionService =
+                new ResumeEditTransactionService(
+                        resumeEventMongoRepository,
+                        resumeEventQueryRepository,
+                        resumeProjectionService);
+    }
+
+    @Test
+    void markEditFailed_clearsPendingProjectionAlongsideEventFailure() {
+        ResumeEventDocument event = org.mockito.Mockito.mock(ResumeEventDocument.class);
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 2))
+                .willReturn(Optional.of(event));
+
+        resumeEditTransactionService.markEditFailed(100L, 2, "ai timeout");
+
+        verify(event).failNow("AI_EDIT_FAILED", "ai timeout");
+        verify(resumeEventMongoRepository).save(event);
+        verify(resumeProjectionService).applyAiFailure(100L, 2);
+    }
+
+    @Test
+    void markEditRequested_bindsAiTaskIdViaAtomicQuery() {
+        ResumeEventDocument updated = org.mockito.Mockito.mock(ResumeEventDocument.class);
+        given(
+                        resumeEventQueryRepository.bindAiTaskIdAndStartProcessing(
+                                eq(100L), eq(2), eq("task-1"), any()))
+                .willReturn(Optional.of(updated));
+
+        resumeEditTransactionService.markEditRequested(100L, 2, "task-1");
+
+        verify(resumeEventQueryRepository)
+                .bindAiTaskIdAndStartProcessing(eq(100L), eq(2), eq("task-1"), any());
+    }
+
+    @Test
+    void markEditRequested_whenBindingFails_throwsIllegalStateException() {
+        given(
+                        resumeEventQueryRepository.bindAiTaskIdAndStartProcessing(
+                                eq(100L), eq(2), eq("task-1"), any()))
+                .willReturn(Optional.empty());
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> resumeEditTransactionService.markEditRequested(100L, 2, "task-1"));
+    }
+}

--- a/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeProjectionServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeProjectionServiceTest.java
@@ -1,0 +1,167 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeDocument;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoQueryRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Update;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeProjectionServiceTest {
+
+    @Mock private ResumeMongoRepository resumeMongoRepository;
+    @Mock private ResumeMongoQueryRepository resumeMongoQueryRepository;
+    @Mock private ResumeEventMongoRepository resumeEventMongoRepository;
+    @Mock private MongoTemplate mongoTemplate;
+
+    private ResumeProjectionService resumeProjectionService;
+
+    @BeforeEach
+    void setUp() {
+        resumeProjectionService =
+                new ResumeProjectionService(
+                        resumeMongoRepository,
+                        resumeMongoQueryRepository,
+                        resumeEventMongoRepository,
+                        mongoTemplate,
+                        Clock.fixed(Instant.parse("2026-03-29T00:00:00Z"), ZoneOffset.UTC));
+    }
+
+    @Test
+    void createProjectionIfNoPendingOrThrow_whenUniqueConstraintTrips_throwsGenerationInProgress() {
+        ResumeDocument projection = mock(ResumeDocument.class);
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+
+        given(resumeMongoRepository.existsByUserIdAndHasPendingWorkTrue(1L)).willReturn(false);
+        given(resumeMongoRepository.save(projection))
+                .willThrow(new DuplicateKeyException("pending unique violation"));
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class,
+                        () ->
+                                resumeProjectionService.createProjectionIfNoPendingOrThrow(
+                                        1L, projection, event));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.RESUME_GENERATION_IN_PROGRESS);
+        verify(resumeEventMongoRepository, never()).save(any());
+    }
+
+    @Test
+    void
+            createProjectionIfNoPendingOrThrow_whenUnexpectedDuplicateKeyTrips_throwsInternalServerError() {
+        ResumeDocument projection = mock(ResumeDocument.class);
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+
+        given(resumeMongoRepository.existsByUserIdAndHasPendingWorkTrue(1L)).willReturn(false);
+        given(resumeMongoRepository.save(projection))
+                .willThrow(new DuplicateKeyException("ux_resumes_resume_id"));
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class,
+                        () ->
+                                resumeProjectionService.createProjectionIfNoPendingOrThrow(
+                                        1L, projection, event));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+        verify(resumeEventMongoRepository, never()).save(any());
+    }
+
+    @Test
+    void markPendingIfIdleOrThrow_whenUniqueConstraintTrips_throwsEditInProgress() {
+        given(mongoTemplate.findAndModify(any(), any(Update.class), eq(ResumeDocument.class)))
+                .willThrow(new DuplicateKeyException("pending unique violation"));
+
+        BusinessException exception =
+                assertThrows(
+                        BusinessException.class,
+                        () -> resumeProjectionService.markPendingIfIdleOrThrow(100L, 1L));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.RESUME_EDIT_IN_PROGRESS);
+    }
+
+    @Test
+    void commitVersionAndApplyProjection_whenCommittingLatestPreview_clearsUnseenPreview() {
+        Instant committedAt = Instant.parse("2026-03-29T00:10:00Z");
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+        ResumeDocument projection = mock(ResumeDocument.class);
+        ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 3))
+                .willReturn(Optional.of(event));
+        given(resumeMongoRepository.findByResumeId(100L)).willReturn(Optional.of(projection));
+        given(projection.getLatestPreviewVersionNo()).willReturn(3);
+
+        resumeProjectionService.commitVersionAndApplyProjection(100L, 3, committedAt);
+
+        verify(event).markPreviewShown(committedAt);
+        verify(event).markCommitted(committedAt);
+        verify(resumeEventMongoRepository).save(event);
+        verify(mongoTemplate)
+                .findAndModify(any(), updateCaptor.capture(), eq(ResumeDocument.class));
+        Document setClause = updateCaptor.getValue().getUpdateObject().get("$set", Document.class);
+        assertThat(setClause).doesNotContainKey("has_unseen_preview");
+        verify(resumeMongoQueryRepository).clearUnseenPreviewIfLatestVersion(100L, 3);
+    }
+
+    @Test
+    void markPreviewShownAndClearUnseen_clearsOnlyMatchingLatestPreviewVersion() {
+        Instant previewShownAt = Instant.parse("2026-03-29T00:10:00Z");
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 3))
+                .willReturn(Optional.of(event));
+
+        resumeProjectionService.markPreviewShownAndClearUnseen(100L, 3, previewShownAt);
+
+        verify(event).markPreviewShown(previewShownAt);
+        verify(resumeEventMongoRepository).save(event);
+        verify(resumeMongoQueryRepository).clearUnseenPreviewIfLatestVersion(100L, 3);
+    }
+
+    @Test
+    void commitVersionAndApplyProjection_whenAlreadyCommitted_isNoOp() {
+        Instant committedAt = Instant.parse("2026-03-29T00:10:00Z");
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+        ResumeDocument projection = mock(ResumeDocument.class);
+
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 3))
+                .willReturn(Optional.of(event));
+        given(resumeMongoRepository.findByResumeId(100L)).willReturn(Optional.of(projection));
+        given(projection.getLatestPreviewVersionNo()).willReturn(3);
+        given(event.getCommittedAt()).willReturn(committedAt);
+
+        resumeProjectionService.commitVersionAndApplyProjection(100L, 3, committedAt);
+
+        verify(resumeEventMongoRepository, never()).save(any());
+        verify(mongoTemplate, never())
+                .findAndModify(any(), any(Update.class), eq(ResumeDocument.class));
+        verify(resumeMongoQueryRepository, never()).clearUnseenPreviewIfLatestVersion(any(), any());
+    }
+}

--- a/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeServiceTest.java
+++ b/src/test/java/com/sipomeokjo/commitme/domain/resume/service/ResumeServiceTest.java
@@ -1,0 +1,299 @@
+package com.sipomeokjo.commitme.domain.resume.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.sipomeokjo.commitme.api.exception.BusinessException;
+import com.sipomeokjo.commitme.api.pagination.CursorParser;
+import com.sipomeokjo.commitme.api.pagination.CursorRequest;
+import com.sipomeokjo.commitme.api.pagination.CursorResponse;
+import com.sipomeokjo.commitme.api.response.ErrorCode;
+import com.sipomeokjo.commitme.domain.company.repository.CompanyRepository;
+import com.sipomeokjo.commitme.domain.outbox.repository.OutboxEventRepository;
+import com.sipomeokjo.commitme.domain.outbox.service.OutboxEventService;
+import com.sipomeokjo.commitme.domain.position.entity.Position;
+import com.sipomeokjo.commitme.domain.position.service.PositionFinder;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeDocument;
+import com.sipomeokjo.commitme.domain.resume.document.ResumeEventDocument;
+import com.sipomeokjo.commitme.domain.resume.dto.ResumeCreateRequest;
+import com.sipomeokjo.commitme.domain.resume.dto.ResumeDetailDto;
+import com.sipomeokjo.commitme.domain.resume.dto.ResumeEditRequest;
+import com.sipomeokjo.commitme.domain.resume.dto.ResumeProfileResponse;
+import com.sipomeokjo.commitme.domain.resume.dto.ResumeVersionDto;
+import com.sipomeokjo.commitme.domain.resume.dto.ResumeVersionSummaryDto;
+import com.sipomeokjo.commitme.domain.resume.entity.ResumeVersionStatus;
+import com.sipomeokjo.commitme.domain.resume.mapper.ResumeMapper;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventAggregationRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventAggregationResult.VersionListResult;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeEventMongoRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoQueryRepository;
+import com.sipomeokjo.commitme.domain.resume.repository.mongo.ResumeMongoRepository;
+import com.sipomeokjo.commitme.global.mongo.MongoSequenceService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeServiceTest {
+
+    @Mock private ResumeMongoRepository resumeMongoRepository;
+    @Mock private ResumeMongoQueryRepository resumeMongoQueryRepository;
+    @Mock private ResumeEventMongoRepository resumeEventMongoRepository;
+    @Mock private ResumeEventAggregationRepository resumeEventAggregationRepository;
+    @Mock private ResumeFinder resumeFinder;
+    @Mock private MongoSequenceService mongoSequenceService;
+    @Mock private PositionFinder positionFinder;
+    @Mock private CompanyRepository companyRepository;
+    @Mock private CursorParser cursorParser;
+    @Mock private ResumeMapper resumeMapper;
+    @Mock private ResumeProfileService resumeProfileService;
+    @Mock private OutboxEventRepository outboxEventRepository;
+    @Mock private OutboxEventService outboxEventService;
+    @Mock private ResumeAiRequestService resumeAiRequestService;
+    @Mock private ResumeEditTransactionService resumeEditTransactionService;
+    @Mock private ResumeProjectionService resumeProjectionService;
+
+    private ResumeService resumeService;
+
+    @BeforeEach
+    void setUp() {
+        resumeService =
+                new ResumeService(
+                        resumeMongoRepository,
+                        resumeMongoQueryRepository,
+                        resumeEventMongoRepository,
+                        resumeEventAggregationRepository,
+                        resumeFinder,
+                        mongoSequenceService,
+                        positionFinder,
+                        companyRepository,
+                        cursorParser,
+                        resumeMapper,
+                        resumeProfileService,
+                        outboxEventRepository,
+                        outboxEventService,
+                        resumeAiRequestService,
+                        resumeEditTransactionService,
+                        resumeProjectionService,
+                        Clock.fixed(Instant.parse("2026-03-29T00:00:00Z"), ZoneOffset.UTC));
+    }
+
+    @Test
+    void create_whenOutboxEnqueueFails_marksInitialEventFailedAndClearsPending() {
+        ResumeCreateRequest request = new ResumeCreateRequest();
+        request.setRepoUrls(List.of("https://github.com/commit-me/repo"));
+        request.setPositionId(10L);
+        request.setName("백엔드 이력서");
+
+        Position position = mock(Position.class);
+        given(positionFinder.getByIdOrThrow(10L)).willReturn(position);
+        given(position.getId()).willReturn(10L);
+        given(position.getName()).willReturn("백엔드");
+        given(mongoSequenceService.nextResumeId()).willReturn(100L);
+        org.mockito.Mockito.doThrow(new IllegalStateException("enqueue failed"))
+                .when(outboxEventService)
+                .enqueue(anyString(), anyString(), anyString(), any());
+
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> resumeService.create(1L, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+        verify(resumeProjectionService).applyCreateCompensation(100L, 1, "enqueue failed");
+    }
+
+    @Test
+    void get_whenPreviewExists_marksPreviewShownViaProjectionTransaction() {
+        ResumeDocument document = mock(ResumeDocument.class);
+        ResumeEventDocument previewEvent =
+                ResumeEventDocument.create(100L, 2, 1L, ResumeVersionStatus.QUEUED, "{}");
+        previewEvent.succeed("{\"summary\":\"preview\"}", Instant.parse("2026-03-29T00:01:00Z"));
+
+        ResumeProfileResponse profileResponse =
+                new ResumeProfileResponse(
+                        100L, "홍길동", null, null, null, null, List.of(), List.of(), List.of(),
+                        List.of(), List.of());
+        ResumeDetailDto detailDto =
+                new ResumeDetailDto(
+                        100L,
+                        "이력서",
+                        true,
+                        10L,
+                        "백엔드",
+                        null,
+                        null,
+                        2,
+                        "{\"summary\":\"preview\"}",
+                        ResumeDetailDto.ResumeDetailProfileDto.from(profileResponse),
+                        null,
+                        Instant.parse("2026-03-29T00:00:00Z"),
+                        Instant.parse("2026-03-29T00:00:00Z"));
+
+        given(resumeFinder.getDocumentByResumeIdAndUserIdOrThrow(100L, 1L)).willReturn(document);
+        given(document.getResumeId()).willReturn(100L);
+        given(document.getCurrentVersionNo()).willReturn(1);
+        given(document.getProfileSnapshot()).willReturn(null);
+        given(resumeProfileService.getProfile(1L, 100L, null)).willReturn(profileResponse);
+        given(
+                        resumeEventMongoRepository.existsByResumeIdAndStatusIn(
+                                100L,
+                                List.of(
+                                        ResumeVersionStatus.QUEUED,
+                                        ResumeVersionStatus.PROCESSING)))
+                .willReturn(true);
+        given(
+                        resumeEventMongoRepository
+                                .findFirstByResumeIdAndStatusAndCommittedAtIsNullAndPreviewShownAtIsNullOrderByVersionNoDesc(
+                                        100L, ResumeVersionStatus.SUCCEEDED))
+                .willReturn(Optional.of(previewEvent));
+        given(resumeMapper.toDetailDtoFromDocument(document, previewEvent, true, profileResponse))
+                .willReturn(detailDto);
+
+        ResumeDetailDto result = resumeService.get(1L, 100L);
+
+        assertThat(result).isSameAs(detailDto);
+        verify(resumeProjectionService)
+                .markPreviewShownAndClearUnseen(anyLong(), anyInt(), any(Instant.class));
+        verify(resumeEventMongoRepository, never()).save(any());
+    }
+
+    @Test
+    void getVersion_doesNotMutateTimedOutEventOnRead() {
+        ResumeDocument document = mock(ResumeDocument.class);
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+        Instant createdAt = Instant.parse("2026-03-29T00:00:00Z");
+        Instant updatedAt = Instant.parse("2026-03-29T00:01:00Z");
+
+        given(resumeFinder.getDocumentByResumeIdAndUserIdOrThrow(100L, 1L)).willReturn(document);
+        given(document.getResumeId()).willReturn(100L);
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 2))
+                .willReturn(Optional.of(event));
+        given(event.getVersionNo()).willReturn(2);
+        given(event.getStatus()).willReturn(ResumeVersionStatus.PROCESSING);
+        given(event.getSnapshot()).willReturn("{\"summary\":\"processing\"}");
+        given(event.getAiTaskId()).willReturn("task-1");
+        given(event.getErrorLog()).willReturn(null);
+        given(event.getStartedAt()).willReturn(createdAt);
+        given(event.getFinishedAt()).willReturn(null);
+        given(event.getCommittedAt()).willReturn(null);
+        given(event.getCreatedAt()).willReturn(createdAt);
+        given(event.getUpdatedAt()).willReturn(updatedAt);
+
+        ResumeVersionDto result = resumeService.getVersion(1L, 100L, 2);
+
+        assertThat(result.getStatus()).isEqualTo(ResumeVersionStatus.PROCESSING);
+        verify(resumeEventMongoRepository, never()).save(any());
+        verify(resumeProjectionService, never()).applyAiFailure(anyLong(), anyInt());
+    }
+
+    @Test
+    void saveVersion_commitsThroughProjectionTransaction() {
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 2))
+                .willReturn(Optional.of(event));
+        given(event.getStatus()).willReturn(ResumeVersionStatus.SUCCEEDED);
+
+        resumeService.saveVersion(1L, 100L, 2);
+
+        verify(resumeProjectionService)
+                .commitVersionAndApplyProjection(anyLong(), anyInt(), any(Instant.class));
+        verify(resumeEventMongoRepository, never()).save(any());
+    }
+
+    @Test
+    void getVersionList_whenPreviewExists_doesNotExceedRequestedLimit() {
+        ResumeEventDocument committedV3 =
+                ResumeEventDocument.create(100L, 3, 1L, ResumeVersionStatus.QUEUED, "{}");
+        committedV3.succeed("{}", Instant.parse("2026-03-29T00:03:00Z"));
+        committedV3.markCommitted(Instant.parse("2026-03-29T00:03:00Z"));
+
+        ResumeEventDocument committedV2 =
+                ResumeEventDocument.create(100L, 2, 1L, ResumeVersionStatus.QUEUED, "{}");
+        committedV2.succeed("{}", Instant.parse("2026-03-29T00:02:00Z"));
+        committedV2.markCommitted(Instant.parse("2026-03-29T00:02:00Z"));
+
+        ResumeEventDocument previewV4 =
+                ResumeEventDocument.create(100L, 4, 1L, ResumeVersionStatus.QUEUED, "{}");
+        previewV4.succeed("{}", Instant.parse("2026-03-29T00:04:00Z"));
+
+        given(resumeEventAggregationRepository.findVersionListPage(100L, null, 2))
+                .willReturn(new VersionListResult(List.of(committedV3, committedV2), previewV4));
+
+        CursorResponse<ResumeVersionSummaryDto> response =
+                resumeService.getVersionList(1L, 100L, new CursorRequest(null, 2));
+
+        assertThat(response.data()).hasSize(2);
+        assertThat(response.data().get(0).versionNo()).isEqualTo(4);
+        assertThat(response.data().get(1).versionNo()).isEqualTo(3);
+        assertThat(response.next()).isEqualTo("3");
+    }
+
+    @Test
+    void getVersionList_whenPreviewExistsAndSizeIsOne_returnsNextCursorFromCommittedEvents() {
+        ResumeEventDocument committedV3 =
+                ResumeEventDocument.create(100L, 3, 1L, ResumeVersionStatus.QUEUED, "{}");
+        committedV3.succeed("{}", Instant.parse("2026-03-29T00:03:00Z"));
+        committedV3.markCommitted(Instant.parse("2026-03-29T00:03:00Z"));
+
+        ResumeEventDocument previewV4 =
+                ResumeEventDocument.create(100L, 4, 1L, ResumeVersionStatus.QUEUED, "{}");
+        previewV4.succeed("{}", Instant.parse("2026-03-29T00:04:00Z"));
+
+        given(resumeEventAggregationRepository.findVersionListPage(100L, null, 1))
+                .willReturn(new VersionListResult(List.of(committedV3), previewV4));
+
+        CursorResponse<ResumeVersionSummaryDto> response =
+                resumeService.getVersionList(1L, 100L, new CursorRequest(null, 1));
+
+        assertThat(response.data()).hasSize(1);
+        assertThat(response.data().getFirst().versionNo()).isEqualTo(4);
+        assertThat(response.next()).isEqualTo("3");
+    }
+
+    @Test
+    void edit_whenMarkEditRequestedFailsAfterAiAccepted_doesNotMarkEditFailed() {
+        ResumeEditRequest request = new ResumeEditRequest("문장 다듬어줘");
+        ResumeEditTransactionService.EditPrepared prepared =
+                new ResumeEditTransactionService.EditPrepared(100L, "이력서", 2, "{}");
+
+        given(resumeEditTransactionService.prepareEdit(1L, 100L)).willReturn(prepared);
+        given(resumeAiRequestService.requestEdit(100L, "{}", "문장 다듬어줘")).willReturn("task-1");
+        given(resumeEditTransactionService.markEditRequested(100L, 2, "task-1"))
+                .willThrow(new IllegalStateException("mongo write failed"));
+
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> resumeService.edit(1L, 100L, request));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+        verify(resumeEditTransactionService, never())
+                .markEditFailed(anyLong(), anyInt(), anyString());
+    }
+
+    @Test
+    void saveVersion_whenAlreadyCommitted_isIdempotentNoOp() {
+        ResumeEventDocument event = mock(ResumeEventDocument.class);
+        given(resumeEventMongoRepository.findByResumeIdAndVersionNo(100L, 2))
+                .willReturn(Optional.of(event));
+        given(event.getStatus()).willReturn(ResumeVersionStatus.SUCCEEDED);
+        given(event.getCommittedAt()).willReturn(Instant.parse("2026-03-29T00:10:00Z"));
+
+        resumeService.saveVersion(1L, 100L, 2);
+
+        verify(resumeProjectionService, never())
+                .commitVersionAndApplyProjection(anyLong(), anyInt(), any(Instant.class));
+    }
+}


### PR DESCRIPTION
## Description

Event Sourcing 기반 이력서 도메인에 MongoDB Aggregation Pipeline 조회 레이어와 이력서 생성 복구 스케줄러를 추가한다. 버전 목록 조회 시 불필요한 MongoDB round-trip을 줄이고, Outbox 누락으로 고착된 CREATE 이벤트를 자동으로 복구한다.

## Related Issues

- Resolves #236 

## Changes Made

### 1. $facet 기반 버전 목록 조회

버전 목록 조회(findVersionListPage)에서 커밋(저장)된 페이지(committedPage)와 최신 SUCCEEDED 이벤트(latestSucceeded) 두 결과가 필요하다. 두 결과가 동일한 outer $match(resume_id, status=SUCCEEDED) 조건을 공유하므로 $facet으로 묶어 단일 aggregation 1회에 처리한다.

**Pipeline 구조**

```
$match(resume_id, status=SUCCEEDED)
└─ $facet
   ├─ committedPage: $match(committed_at≠null [, version_no < cursor]) → $sort(version_no DESC) → $limit(pageSize+1)
   └─ latestSucceeded: $sort(version_no DESC) → $limit(1)
```

### 2. 생성 이벤트 Outbox 테이블 누락 시나리오 대비 복구 스케줄러 추가 

이력서 생성 흐름에서 MongoDB에 QUEUED 이벤트는 저장됐지만 Outbox 발행이 실패한 경우, AI 서버로 요청이 전달되지 않아 해당 이벤트가 영구적으로 고착될 수 있다. 

매 60초(app.resume.create-repair-delay-ms)마다 versionNo=1, status=QUEUED, aiTaskId=null, createdAt < (now - graceMinutes) 조건으로 고착 이벤트를 조회한다. Outbox(AI_JOB_REQUESTED)가 존재하면 스킵하고, 없으면 event.failNow() + resumeProjectionService.applyAiFailure()로 자동 FAILED 전환한다. 

EDIT 이벤트(versionNo≥2)는 Outbox 누락 패턴이 달라 이 스케줄러 범위 밖으로 분리한다.

**동작 방식**

```
매 60초 실행 (app.resume.create-repair-delay-ms)
└─ versionNo=1, status=QUEUED, aiTaskId=null, createdAt < (now - graceMinutes) 조회
   ├─ Outbox(AI_JOB_REQUESTED) 존재 → 스킵 (정상 진행 중)
   └─ Outbox 없음 → event.failNow() + resumeProjectionService.applyAiFailure()
```

## Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

## Additional Notes

**왜 $facet을 outer $match 공유 조건에만 적용하는가**
`$facet` 내부 브랜치는 서로 독립적으로 실행되므로, outer `$match`로 공유 조건을 먼저 필터링한 뒤 분기해야 인덱스 활용이 가능하다. 공유 조건 없이 `$facet`만 사용하면 각 브랜치가 전체 컬렉션을 스캔한다.

**Aggregation 인덱스 활용 확인**
outer $match(resume_id, status=SUCCEEDED)가 ix_resume_events_preview_lookup 인덱스를 IXSCAN으로 활용한다. $facet 내부 브랜치의 추가 필터(committed_at != null)는 outer $match 이후 인메모리에서 처리되며, $internalFacetTeeConsumer가 단일 커서를 두 브랜치에 복제한다.
<img width="1617" height="935" alt="Screenshot 2026-03-30 at 11 56 37" src="https://github.com/user-attachments/assets/27240b49-1e2c-4c54-94c3-21175f68510b" />
COLLSCAN 없음, 인덱스 활용 정상 확인.